### PR TITLE
Added style attribute to let event markers overflow

### DIFF
--- a/lib/src/customization/calendar_style.dart
+++ b/lib/src/customization/calendar_style.dart
@@ -72,6 +72,11 @@ class CalendarStyle {
   /// * `false` - Today will have higher priority than SelectedDay
   final bool renderSelectedFirst;
 
+  /// Specifies if the rendered event markers for a date can overflow the boundaries of that date cell.
+  /// * `true` - The event markers will draw over the cell boundaries
+  /// * `false` - The event markers will not draw over the cell boundaries and will be cut off if they are too big.
+  final bool canEventMarkersOverflow;
+
   const CalendarStyle({
     this.weekdayStyle = const TextStyle(),
     this.weekendStyle = const TextStyle(color: const Color(0xFFF44336)), // Material red[500]
@@ -93,5 +98,6 @@ class CalendarStyle {
     this.markersMaxAmount = 4,
     this.outsideDaysVisible = true,
     this.renderSelectedFirst = true,
+    this.canEventMarkersOverflow = false,
   });
 }

--- a/lib/table_calendar.dart
+++ b/lib/table_calendar.dart
@@ -556,6 +556,7 @@ class _TableCalendarState extends State<TableCalendar> with SingleTickerProvider
         content = Stack(
           alignment: widget.calendarStyle.markersAlignment,
           children: children,
+          overflow: widget.calendarStyle.canEventMarkersOverflow ? Overflow.visible : Overflow.clip,
         );
       }
     }


### PR DESCRIPTION
I have a project in which the event markers can occasionally get too big for the normal stack boundaries and will get clipped. To overcome it, I have added a boolean for the CalendarStyle to let me toggle the overflow behavior of the surrounding Stack.