### PR TITLE
Update calendar controller events when widget updates.

### DIFF
--- a/lib/src/calendar.dart
+++ b/lib/src/calendar.dart
@@ -183,6 +183,14 @@ class _TableCalendarState extends State<TableCalendar> with SingleTickerProvider
     );
   }
 
+  @override
+  void didUpdateWidget(TableCalendar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.events != widget.events) {
+      widget.calendarController._events = widget.events;
+    }
+  }
+
   void _selectedDayCallback(DateTime day) {
     if (widget.onDaySelected != null) {
       widget.onDaySelected(day, widget.calendarController.visibleEvents[_getEventKey(day)] ?? []);


### PR DESCRIPTION
Taking advantage of the `didUpdateWidget` callback in state, we can update the CalendarController automatically when the widget's events are changed.

Exposing the events setter on the CalendarController and requiring the user to supply events through it seems a bit like an anti-pattern in Flutter. 

I've tested and it works for my narrow use case. Please run it through your own tests during consideration.