### PR TITLE
Disable selected day / today style #167

### DIFF
--- a/lib/src/customization/calendar_style.dart
+++ b/lib/src/customization/calendar_style.dart
@@ -83,6 +83,12 @@ class CalendarStyle {
   /// * `false` - Event markers will not be drawn over the cell boundaries and will be clipped if they are too big
   final bool canEventMarkersOverflow;
 
+  /// Highlight selected day.
+  final bool selectedHighlighting;
+
+  /// Highlight today.
+  final bool todayHighlighting;
+
   const CalendarStyle({
     this.weekdayStyle = const TextStyle(),
     this.weekendStyle = const TextStyle(color: const Color(0xFFF44336)), // Material red[500]
@@ -107,5 +113,7 @@ class CalendarStyle {
     this.renderDaysOfWeek = true,
     this.contentPadding = const EdgeInsets.only(bottom: 4.0, left: 8.0, right: 8.0),
     this.canEventMarkersOverflow = false,
+    this.selectedHighlighting = true,
+    this.todayHighlighting = true,
   });
 }

--- a/lib/src/widgets/cell_widget.dart
+++ b/lib/src/widgets/cell_widget.dart
@@ -42,11 +42,11 @@ class _CellWidget extends StatelessWidget {
   }
 
   Decoration _buildCellDecoration() {
-    if (isSelected && calendarStyle.renderSelectedFirst) {
+    if (isSelected && calendarStyle.renderSelectedFirst && calendarStyle.selectedHighlighting) {
       return BoxDecoration(shape: BoxShape.circle, color: calendarStyle.selectedColor);
-    } else if (isToday) {
+    } else if (isToday && calendarStyle.todayHighlighting) {
       return BoxDecoration(shape: BoxShape.circle, color: calendarStyle.todayColor);
-    } else if (isSelected) {
+    } else if (isSelected && calendarStyle.selectedHighlighting) {
       return BoxDecoration(shape: BoxShape.circle, color: calendarStyle.selectedColor);
     } else {
       return BoxDecoration(shape: BoxShape.circle);
@@ -56,11 +56,11 @@ class _CellWidget extends StatelessWidget {
   TextStyle _buildCellTextStyle() {
     if (isUnavailable) {
       return calendarStyle.unavailableStyle;
-    } else if (isSelected && calendarStyle.renderSelectedFirst) {
+    } else if (isSelected && calendarStyle.renderSelectedFirst && calendarStyle.selectedHighlighting) {
       return calendarStyle.selectedStyle;
-    } else if (isToday) {
+    } else if (isToday && calendarStyle.todayHighlighting) {
       return calendarStyle.todayStyle;
-    } else if (isSelected) {
+    } else if (isSelected && calendarStyle.selectedHighlighting) {
       return calendarStyle.selectedStyle;
     } else if (isOutsideMonth && isHoliday) {
       return calendarStyle.outsideHolidayStyle;


### PR DESCRIPTION
- I added two new `calendarStyle` properties to allow controlling the general styling of selected days and today
- Defaults to `true` for both values
- Properties aren't mandatory to set
- Existing implementations shouldn't need any changes.

Related issue: #167 