### PR TITLE
Call onVisibleDaysChanged() once when calendar gets initiialized

### DIFF
--- a/lib/src/calendar_controller.dart
+++ b/lib/src/calendar_controller.dart
@@ -141,6 +141,11 @@ class CalendarController {
           );
         }
       });
+      onVisibleDaysChanged(
+        _getFirstDay(includeInvisible: _includeInvisibleDays),
+        _getLastDay(includeInvisible: _includeInvisibleDays),
+        _calendarFormat.value,
+      );
     }
   }
 


### PR DESCRIPTION
This resolves #200 by calling the callback `onVisibleDaysChanged()` once when the `CalendarController` gets initialized.