### PR TITLE
Chevron icon colors should automatically change to white in dark mode.

### DIFF
--- a/lib/src/customization/header_style.dart
+++ b/lib/src/customization/header_style.dart
@@ -86,8 +86,8 @@ class HeaderStyle {
     this.rightChevronPadding = const EdgeInsets.all(12.0),
     this.leftChevronMargin = const EdgeInsets.symmetric(horizontal: 8.0),
     this.rightChevronMargin = const EdgeInsets.symmetric(horizontal: 8.0),
-    this.leftChevronIcon = const Icon(Icons.chevron_left, color: Colors.black),
-    this.rightChevronIcon = const Icon(Icons.chevron_right, color: Colors.black),
+    this.leftChevronIcon = const Icon(Icons.chevron_left),
+    this.rightChevronIcon = const Icon(Icons.chevron_right),
     this.decoration = const BoxDecoration(),
   });
 }


### PR DESCRIPTION
Like the title says, we should not hard code colors to black for default Icon since the colors should be obtained from current Theme data.