### PR TITLE
Add properties so users can provide BoxDecorations to rows

### DIFF
--- a/lib/src/calendar.dart
+++ b/lib/src/calendar.dart
@@ -524,7 +524,7 @@ class _TableCalendarState extends State<TableCalendar> with SingleTickerProvider
 
   TableRow _buildDaysOfWeek() {
     return TableRow(
-      decoration: widget.calendarStyle.labelRowBoxDecoration,
+      decoration: widget.daysOfWeekStyle.decoration,
       children: widget.calendarController._visibleDays.value.take(7).map((date) {
         final weekdayString = widget.daysOfWeekStyle.dowTextBuilder != null
             ? widget.daysOfWeekStyle.dowTextBuilder(date, widget.locale)
@@ -549,7 +549,7 @@ class _TableCalendarState extends State<TableCalendar> with SingleTickerProvider
 
   TableRow _buildTableRow(List<DateTime> days) {
     return TableRow(
-      decoration: widget.calendarStyle.dayRowBoxDecoration,
+      decoration: widget.calendarStyle.contentDecoration,
       children: days.map((date) => _buildTableCell(date)).toList(),
     );
   }

--- a/lib/src/calendar.dart
+++ b/lib/src/calendar.dart
@@ -524,6 +524,7 @@ class _TableCalendarState extends State<TableCalendar> with SingleTickerProvider
 
   TableRow _buildDaysOfWeek() {
     return TableRow(
+      decoration: widget.calendarStyle.labelRowBoxDecoration,
       children: widget.calendarController._visibleDays.value.take(7).map((date) {
         final weekdayString = widget.daysOfWeekStyle.dowTextBuilder != null
             ? widget.daysOfWeekStyle.dowTextBuilder(date, widget.locale)
@@ -547,7 +548,10 @@ class _TableCalendarState extends State<TableCalendar> with SingleTickerProvider
   }
 
   TableRow _buildTableRow(List<DateTime> days) {
-    return TableRow(children: days.map((date) => _buildTableCell(date)).toList());
+    return TableRow(
+      decoration: widget.calendarStyle.dayRowBoxDecoration,
+      children: days.map((date) => _buildTableCell(date)).toList(),
+    );
   }
 
   // TableCell will have equal width and height

--- a/lib/src/customization/calendar_style.dart
+++ b/lib/src/customization/calendar_style.dart
@@ -5,11 +5,8 @@ part of table_calendar;
 
 /// Class containing styling for `TableCalendar`'s content.
 class CalendarStyle {
-  /// BoxDecoration for the top row of the table
-  final BoxDecoration labelRowBoxDecoration;
-
   /// BoxDecoration for each interior row of the table
-  final BoxDecoration dayRowBoxDecoration;
+  final BoxDecoration contentDecoration;
 
   /// Style of foreground Text for regular weekdays.
   final TextStyle weekdayStyle;
@@ -96,8 +93,7 @@ class CalendarStyle {
   final bool highlightToday;
 
   const CalendarStyle({
-    this.labelRowBoxDecoration = const BoxDecoration(),
-    this.dayRowBoxDecoration = const BoxDecoration(),
+    this.contentDecoration = const BoxDecoration(),
     this.weekdayStyle = const TextStyle(),
     this.weekendStyle = const TextStyle(color: const Color(0xFFF44336)), // Material red[500]
     this.holidayStyle = const TextStyle(color: const Color(0xFFF44336)), // Material red[500]

--- a/lib/src/customization/calendar_style.dart
+++ b/lib/src/customization/calendar_style.dart
@@ -5,6 +5,12 @@ part of table_calendar;
 
 /// Class containing styling for `TableCalendar`'s content.
 class CalendarStyle {
+  /// BoxDecoration for the top row of the table
+  final BoxDecoration labelRowBoxDecoration;
+
+  /// BoxDecoration for each interior row of the table
+  final BoxDecoration dayRowBoxDecoration;
+
   /// Style of foreground Text for regular weekdays.
   final TextStyle weekdayStyle;
 
@@ -90,6 +96,8 @@ class CalendarStyle {
   final bool highlightToday;
 
   const CalendarStyle({
+    this.labelRowBoxDecoration = const BoxDecoration(),
+    this.dayRowBoxDecoration = const BoxDecoration(),
     this.weekdayStyle = const TextStyle(),
     this.weekendStyle = const TextStyle(color: const Color(0xFFF44336)), // Material red[500]
     this.holidayStyle = const TextStyle(color: const Color(0xFFF44336)), // Material red[500]

--- a/lib/src/customization/days_of_week_style.dart
+++ b/lib/src/customization/days_of_week_style.dart
@@ -15,6 +15,9 @@ class DaysOfWeekStyle {
   /// ```
   final TextBuilder dowTextBuilder;
 
+  /// BoxDecoration for the top row of the table
+  final BoxDecoration decoration;
+
   /// Style for weekdays on the top of Calendar.
   final TextStyle weekdayStyle;
 
@@ -23,6 +26,7 @@ class DaysOfWeekStyle {
 
   const DaysOfWeekStyle({
     this.dowTextBuilder,
+    this.decoration = const BoxDecoration(),
     this.weekdayStyle = const TextStyle(color: const Color(0xFF616161)), // Material grey[700]
     this.weekendStyle = const TextStyle(color: const Color(0xFFF44336)), // Material red[500]
   });


### PR DESCRIPTION
<img width="988" alt="Screen Shot 2020-04-17 at 2 52 43 PM" src="https://user-images.githubusercontent.com/3495974/79603910-2f5bb380-80bb-11ea-9959-f394cd469fb3.png">

Without these BoxDecorations users can only style columns and there are problems with that especially when background colors are desired.