### PR TITLE
Bring CalendarController inside the plugin and expose it through callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.0.0]
+
+* Breaking: CalendarController no longer needs to be instantiated manually. Instead it's provided as a parameter in callbacks and can also be saved inside a variable by the user. Example project updated. See the example for details.
+* Make CalendarController selectNext and selectPrevious methods public.
+
 ## [2.2.3]
 
 * Added onCalendarCreated callback
@@ -108,7 +113,7 @@
 
 * Added programmatic selectedDay
 * Removed onFormatChanged callback - it is now integrated into onVisibleDaysChanged callback
-* Improved onVisibleDaysChanged behavior 
+* Improved onVisibleDaysChanged behavior
 * Fixed issue with empty Calendar row
 * Changed default FormatButton texts
 * Updated example project

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -70,7 +70,6 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
     };
 
     _selectedEvents = _events[_selectedDay] ?? [];
-    _calendarController = CalendarController();
 
     _animationController = AnimationController(
       vsync: this,
@@ -87,18 +86,18 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
     super.dispose();
   }
 
-  void _onDaySelected(DateTime day, List events) {
+  void _onDaySelected(DateTime day, List events, CalendarController controller) {
     print('CALLBACK: _onDaySelected');
     setState(() {
       _selectedEvents = events;
     });
   }
 
-  void _onVisibleDaysChanged(DateTime first, DateTime last, CalendarFormat format) {
+  void _onVisibleDaysChanged(DateTime first, DateTime last, CalendarFormat format, CalendarController controller) {
     print('CALLBACK: _onVisibleDaysChanged');
   }
 
-  void _onCalendarCreated(DateTime first, DateTime last, CalendarFormat format) {
+  void _onCalendarCreated(DateTime first, DateTime last, CalendarFormat format, CalendarController controller) {
     print('CALLBACK: _onCalendarCreated');
   }
 
@@ -113,8 +112,8 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
         children: <Widget>[
           // Switch out 2 lines below to play with TableCalendar's settings
           //-----------------------
-          _buildTableCalendar(),
-          // _buildTableCalendarWithBuilders(),
+          // _buildTableCalendar(),
+          _buildTableCalendarWithBuilders(),
           const SizedBox(height: 8.0),
           _buildButtons(),
           const SizedBox(height: 8.0),
@@ -127,7 +126,6 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
   // Simple TableCalendar configuration (using Styles)
   Widget _buildTableCalendar() {
     return TableCalendar(
-      calendarController: _calendarController,
       events: _events,
       holidays: _holidays,
       startingDayOfWeek: StartingDayOfWeek.monday,
@@ -154,7 +152,6 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
   Widget _buildTableCalendarWithBuilders() {
     return TableCalendar(
       locale: 'pl_PL',
-      calendarController: _calendarController,
       events: _events,
       holidays: _holidays,
       initialCalendarFormat: CalendarFormat.month,
@@ -178,7 +175,7 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
         formatButtonVisible: false,
       ),
       builders: CalendarBuilders(
-        selectedDayBuilder: (context, date, _) {
+        selectedDayBuilder: (context, date, controller, _) {
           return FadeTransition(
             opacity: Tween(begin: 0.0, end: 1.0).animate(_animationController),
             child: Container(
@@ -194,7 +191,7 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
             ),
           );
         },
-        todayDayBuilder: (context, date, _) {
+        todayDayBuilder: (context, date, controller, _) {
           return Container(
             margin: const EdgeInsets.all(4.0),
             padding: const EdgeInsets.only(top: 5.0, left: 6.0),
@@ -207,7 +204,7 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
             ),
           );
         },
-        markersBuilder: (context, date, events, holidays) {
+        markersBuilder: (context, date, controller, events, holidays) {
           final children = <Widget>[];
 
           if (events.isNotEmpty) {
@@ -215,7 +212,7 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
               Positioned(
                 right: 1,
                 bottom: 1,
-                child: _buildEventsMarker(date, events),
+                child: _buildEventsMarker(date, events, controller),
               ),
             );
           }
@@ -233,8 +230,8 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
           return children;
         },
       ),
-      onDaySelected: (date, events) {
-        _onDaySelected(date, events);
+      onDaySelected: (date, events, controller) {
+        _onDaySelected(date, events, controller);
         _animationController.forward(from: 0.0);
       },
       onVisibleDaysChanged: _onVisibleDaysChanged,
@@ -242,14 +239,14 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
     );
   }
 
-  Widget _buildEventsMarker(DateTime date, List events) {
+  Widget _buildEventsMarker(DateTime date, List events, CalendarController controller) {
     return AnimatedContainer(
       duration: const Duration(milliseconds: 300),
       decoration: BoxDecoration(
         shape: BoxShape.rectangle,
-        color: _calendarController.isSelected(date)
+        color: controller.isSelected(date)
             ? Colors.brown[500]
-            : _calendarController.isToday(date) ? Colors.brown[300] : Colors.blue[400],
+            : controller.isToday(date) ? Colors.brown[300] : Colors.blue[400],
       ),
       width: 16.0,
       height: 16.0,

--- a/lib/src/calendar.dart
+++ b/lib/src/calendar.dart
@@ -216,19 +216,6 @@ class _TableCalendarState extends State<TableCalendar> with SingleTickerProvider
   void initState() {
     super.initState();
     calendarController = CalendarController();
-    calendarController._init(
-      events: widget.events,
-      holidays: widget.holidays,
-      initialDay: widget.initialSelectedDay,
-      initialFormat: widget.initialCalendarFormat,
-      availableCalendarFormats: widget.availableCalendarFormats,
-      useNextCalendarFormat: widget.headerStyle.formatButtonShowsNext,
-      startingDayOfWeek: widget.startingDayOfWeek,
-      selectedDayCallback: _selectedDayCallback,
-      onVisibleDaysChanged: widget.onVisibleDaysChanged,
-      onCalendarCreated: widget.onCalendarCreated,
-      includeInvisibleDays: widget.calendarStyle.outsideDaysVisible,
-    );
   }
 
   @override
@@ -248,6 +235,22 @@ class _TableCalendarState extends State<TableCalendar> with SingleTickerProvider
     if (widget.onDaySelected != null) {
       widget.onDaySelected(day, calendarController.visibleEvents[_getEventKey(day)] ?? [], calendarController);
     }
+  }
+
+  void initController() {
+    calendarController._init(
+      events: widget.events,
+      holidays: widget.holidays,
+      initialDay: widget.initialSelectedDay,
+      initialFormat: widget.initialCalendarFormat,
+      availableCalendarFormats: widget.availableCalendarFormats,
+      useNextCalendarFormat: widget.headerStyle.formatButtonShowsNext,
+      startingDayOfWeek: widget.startingDayOfWeek,
+      selectedDayCallback: _selectedDayCallback,
+      onVisibleDaysChanged: widget.onVisibleDaysChanged,
+      onCalendarCreated: widget.onCalendarCreated,
+      includeInvisibleDays: widget.calendarStyle.outsideDaysVisible,
+    );
   }
 
   void _selectPrevious() {
@@ -335,6 +338,8 @@ class _TableCalendarState extends State<TableCalendar> with SingleTickerProvider
 
   @override
   Widget build(BuildContext context) {
+    initController();
+
     return ClipRect(
       child: Column(
         mainAxisSize: MainAxisSize.min,

--- a/lib/src/calendar.dart
+++ b/lib/src/calendar.dart
@@ -4,13 +4,15 @@
 part of table_calendar;
 
 /// Callback exposing currently selected day.
-typedef void OnDaySelected(DateTime day, List events);
+typedef void OnDaySelected(DateTime day, List events, CalendarController calenderController);
 
 /// Callback exposing currently visible days (first and last of them), as well as current `CalendarFormat`.
-typedef void OnVisibleDaysChanged(DateTime first, DateTime last, CalendarFormat format);
+typedef void OnVisibleDaysChanged(
+    DateTime first, DateTime last, CalendarFormat format, CalendarController calenderController);
 
 /// Callback exposing initially visible days (first and last of them), as well as initial `CalendarFormat`.
-typedef void OnCalendarCreated(DateTime first, DateTime last, CalendarFormat format);
+typedef void OnCalendarCreated(
+    DateTime first, DateTime last, CalendarFormat format, CalendarController calenderController);
 
 /// Signature for reacting to header gestures. Exposes current month and year as a `DateTime` object.
 typedef void HeaderGestureCallback(DateTime focusedDay);
@@ -46,10 +48,6 @@ enum AvailableGestures { none, verticalSwipe, horizontalSwipe, all }
 
 /// Highly customizable, feature-packed Flutter Calendar with gestures, animations and multiple formats.
 class TableCalendar extends StatefulWidget {
-  /// Controller required for `TableCalendar`.
-  /// Use it to update `events`, `holidays`, etc.
-  CalendarController calendarController;
-
   /// Locale to format `TableCalendar` dates with, for example: `'en_US'`.
   ///
   /// If nothing is provided, a default locale will be used.
@@ -231,7 +229,6 @@ class _TableCalendarState extends State<TableCalendar> with SingleTickerProvider
       onCalendarCreated: widget.onCalendarCreated,
       includeInvisibleDays: widget.calendarStyle.outsideDaysVisible,
     );
-    widget.calendarController = calendarController;
   }
 
   @override
@@ -249,19 +246,19 @@ class _TableCalendarState extends State<TableCalendar> with SingleTickerProvider
 
   void _selectedDayCallback(DateTime day) {
     if (widget.onDaySelected != null) {
-      widget.onDaySelected(day, calendarController.visibleEvents[_getEventKey(day)] ?? []);
+      widget.onDaySelected(day, calendarController.visibleEvents[_getEventKey(day)] ?? [], calendarController);
     }
   }
 
   void _selectPrevious() {
     setState(() {
-      calendarController._selectPrevious();
+      calendarController.selectPrevious();
     });
   }
 
   void _selectNext() {
     setState(() {
-      calendarController._selectNext();
+      calendarController.selectNext();
     });
   }
 
@@ -274,7 +271,7 @@ class _TableCalendarState extends State<TableCalendar> with SingleTickerProvider
 
   void _onDayLongPressed(DateTime day) {
     if (widget.onDayLongPressed != null) {
-      widget.onDayLongPressed(day, calendarController.visibleEvents[_getEventKey(day)] ?? []);
+      widget.onDayLongPressed(day, calendarController.visibleEvents[_getEventKey(day)] ?? [], calendarController);
     }
   }
 

--- a/lib/src/calendar_controller.dart
+++ b/lib/src/calendar_controller.dart
@@ -135,21 +135,15 @@ class CalendarController {
             !_isSameDay(_visibleDays.value.last, _previousLastDay)) {
           _previousFirstDay = _visibleDays.value.first;
           _previousLastDay = _visibleDays.value.last;
-          onVisibleDaysChanged(
-            _getFirstDay(includeInvisible: _includeInvisibleDays),
-            _getLastDay(includeInvisible: _includeInvisibleDays),
-            _calendarFormat.value,
-          );
+          onVisibleDaysChanged(_getFirstDay(includeInvisible: _includeInvisibleDays),
+              _getLastDay(includeInvisible: _includeInvisibleDays), _calendarFormat.value, this);
         }
       });
     }
 
     if (onCalendarCreated != null) {
-      onCalendarCreated(
-        _getFirstDay(includeInvisible: _includeInvisibleDays),
-        _getLastDay(includeInvisible: _includeInvisibleDays),
-        _calendarFormat.value,
-      );
+      onCalendarCreated(_getFirstDay(includeInvisible: _includeInvisibleDays),
+          _getLastDay(includeInvisible: _includeInvisibleDays), _calendarFormat.value, this);
     }
   }
 
@@ -240,10 +234,11 @@ class CalendarController {
     return formats[id];
   }
 
-  String _getFormatButtonText() =>
-      _useNextCalendarFormat ? _availableCalendarFormats[_nextFormat()] : _availableCalendarFormats[_calendarFormat.value];
+  String _getFormatButtonText() => _useNextCalendarFormat
+      ? _availableCalendarFormats[_nextFormat()]
+      : _availableCalendarFormats[_calendarFormat.value];
 
-  void _selectPrevious() {
+  void selectPrevious() {
     if (calendarFormat == CalendarFormat.month) {
       _selectPreviousMonth();
     } else if (calendarFormat == CalendarFormat.twoWeeks) {
@@ -256,7 +251,7 @@ class CalendarController {
     _decrementPage();
   }
 
-  void _selectNext() {
+  void selectNext() {
     if (calendarFormat == CalendarFormat.month) {
       _selectNextMonth();
     } else if (calendarFormat == CalendarFormat.twoWeeks) {
@@ -394,7 +389,8 @@ class CalendarController {
   }
 
   DateTime _lastDayOfMonth(DateTime month) {
-    final date = month.month < 12 ? DateTime.utc(month.year, month.month + 1, 1, 12) : DateTime.utc(month.year + 1, 1, 1, 12);
+    final date =
+        month.month < 12 ? DateTime.utc(month.year, month.month + 1, 1, 12) : DateTime.utc(month.year + 1, 1, 1, 12);
     return date.subtract(const Duration(days: 1));
   }
 

--- a/lib/src/customization/calendar_builders.dart
+++ b/lib/src/customization/calendar_builders.dart
@@ -6,18 +6,21 @@ part of table_calendar;
 /// Main Builder signature for `TableCalendar`. Contains `date` and list of all `events` associated with that `date`.
 /// Note that most of the time, `events` param will be ommited, however it is there if needed.
 /// `events` param can be null.
-typedef FullBuilder = Widget Function(BuildContext context, DateTime date, List events);
+typedef FullBuilder = Widget Function(
+    BuildContext context, DateTime date, CalendarController calendarController, List events);
 
 /// Builder signature for a list of event markers. Contains `date` and list of all `events` associated with that `date`.
 /// Both `events` and `holidays` params can be null.
-typedef FullListBuilder = List<Widget> Function(BuildContext context, DateTime date, List events, List holidays);
+typedef FullListBuilder = List<Widget> Function(
+    BuildContext context, DateTime date, CalendarController calendarController, List events, List holidays);
 
 /// Builder signature for weekday names row. Contains `weekday` string, which is formatted by `dowTextBuilder`
 /// or by default function (DateFormat.E(widget.locale).format(date)), if `dowTextBuilder` is null.
-typedef DowBuilder = Widget Function(BuildContext context, String weekday);
+typedef DowBuilder = Widget Function(BuildContext context, CalendarController calendarController, String weekday);
 
 /// Builder signature for a single event marker. Contains `date` and a single `event` associated with that `date`.
-typedef SingleMarkerBuilder = Widget Function(BuildContext context, DateTime date, dynamic event);
+typedef SingleMarkerBuilder = Widget Function(
+    BuildContext context, DateTime date, CalendarController calendarController, dynamic event);
 
 /// Class containing all custom Builders for `TableCalendar`.
 class CalendarBuilders {


### PR DESCRIPTION
Breaking change that will require a major version bump. There is a big problem in the current architecture of the package. Two separate objects: TableCalendar and CalendarController. The state of TableCalendar completely depends on the state of CalendarController but users are responsible for instantiating each of these objects separately of one another themselves. This breaks encapsulation principle of object oriented design and makes the package difficult to use. If users want 3 calendars, they must instantiate 3 calendarcontroller, 3 tablecalendar and map the state of each calendar controller to the correct state of the specific tablecalendar that maps to that calendarcontroller. Presumably CalendarController was created for abstraction and/or to have TableCalendar be a smaller object. However the way it was implemented was causing significant problems with both hot reload and statefulness. This PR resolves those issues. Users no longer need to instantiate their own CalendarController. CalendarController is now inside of TableCalendar and instantiation occurs automatically. If the user needs to access the state of CalendarController for the builders, it is exposed as parameters.

Fixes #243 
Fixes #248 

Let me know if I missed anything.