### PR TITLE
Added option to fit calendar size to parent widget

### DIFF
--- a/lib/table_calendar.dart
+++ b/lib/table_calendar.dart
@@ -3,6 +3,7 @@
 
 library table_calendar;
 
+import 'dart:core';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:simple_gesture_detector/simple_gesture_detector.dart';


### PR DESCRIPTION
Added an option to fit the calendar content itself into the parent object to keep it within the screen.

When the [expand] option is set to true, this option will be applied.

Also, to apply this option, the [heightOfDayOfWeekLabel] option allows you to set the height of the day of the week label.

Also, a border can be added to each calendar cell using [calendarContentBorder] option.

The end result is a calendar like the following

![Screenshot_1595692046](https://user-images.githubusercontent.com/45095843/88460822-147ab580-ceda-11ea-9ac1-8837ad96de5e.png)
