### PR TITLE
Modified to allow header title builder

### DIFF
--- a/lib/src/calendar.dart
+++ b/lib/src/calendar.dart
@@ -376,7 +376,10 @@ class _TableCalendarState extends State<TableCalendar> with SingleTickerProvider
         child: GestureDetector(
           onTap: _onHeaderTapped,
           onLongPress: _onHeaderLongPressed,
-          child: Text(
+          child: widget.headerStyle.titleBuilder != null
+              ? widget.headerStyle
+                  .titleBuilder(widget.calendarController.focusedDay)
+              : Text(
             widget.headerStyle.titleTextBuilder != null
                 ? widget.headerStyle.titleTextBuilder(widget.calendarController.focusedDay, widget.locale)
                 : DateFormat.yMMMM(widget.locale).format(widget.calendarController.focusedDay),

--- a/lib/src/customization/header_style.dart
+++ b/lib/src/customization/header_style.dart
@@ -16,6 +16,9 @@ class HeaderStyle {
   /// * `false` - the button will show current CalendarFormat
   final bool formatButtonShowsNext;
 
+  /// Use to customize header's title using different widget
+  final Widget Function(DateTime date) titleBuilder;
+
   /// Use to customize header's title text (eg. with different `DateFormat`).
   /// You can use `String` transformations to further customize the text.
   /// Defaults to simple `'yMMMM'` format (eg. January 2019, February 2019, March 2019, etc.).
@@ -74,6 +77,7 @@ class HeaderStyle {
   final BoxDecoration decoration;
 
   const HeaderStyle({
+    this.titleBuilder,
     this.centerHeaderTitle = false,
     this.formatButtonVisible = true,
     this.formatButtonShowsNext = true,


### PR DESCRIPTION
Hi,
I was integrating table calendar in one of my plugins. And I wanted to customize the header title beyond what the styles supported. So I added this titleBuilder in HeaderStyle, using which user can complete use their own widget in title instead of default text.

If you think it might be useful for others too and is good, you can accept this PR.

If you have any issues or problems regarding this PR, feel free to contact.