### PR TITLE
Week number feature (fixes #523)

### DIFF
--- a/lib/src/customization/calendar_builders.dart
+++ b/lib/src/customization/calendar_builders.dart
@@ -78,6 +78,10 @@ class CalendarBuilders<T> {
   /// Use to customize header's title using different widget
   final DayBuilder? headerTitleBuilder;
 
+  /// Custom builder for number of the week labels.
+  final Widget? Function(BuildContext context, int weekNumber)?
+      weekNumberBuilder;
+
   /// Creates `CalendarBuilders` for `TableCalendar` widget.
   const CalendarBuilders({
     this.prioritizedBuilder,
@@ -95,5 +99,6 @@ class CalendarBuilders<T> {
     this.markerBuilder,
     this.dowBuilder,
     this.headerTitleBuilder,
+    this.weekNumberBuilder,
   });
 }

--- a/lib/src/customization/calendar_style.dart
+++ b/lib/src/customization/calendar_style.dart
@@ -124,6 +124,9 @@ class CalendarStyle {
   /// TextStyle for day cells that are marked as holidays by `holidayPredicate`.
   final TextStyle holidayTextStyle;
 
+  /// TextStyle for week number.
+  final TextStyle weekNumberTextStyle;
+
   /// Decoration for day cells that are marked as holidays by `holidayPredicate`.
   final Decoration holidayDecoration;
 
@@ -215,6 +218,8 @@ class CalendarStyle {
     this.weekendTextStyle = const TextStyle(color: const Color(0xFF5A5A5A)),
     this.weekendDecoration = const BoxDecoration(shape: BoxShape.circle),
     this.defaultTextStyle = const TextStyle(),
+    this.weekNumberTextStyle =
+        const TextStyle(fontSize: 12, color: const Color(0xFFBFBFBF)),
     this.defaultDecoration = const BoxDecoration(shape: BoxShape.circle),
     this.rowDecoration = const BoxDecoration(),
     this.tableBorder = const TableBorder(),

--- a/lib/src/table_calendar.dart
+++ b/lib/src/table_calendar.dart
@@ -150,6 +150,9 @@ class TableCalendar<T> extends StatefulWidget {
   /// Use those to fully tailor the UI.
   final CalendarBuilders<T> calendarBuilders;
 
+  /// Whether to display week numbers on calendar.
+  final bool weekNumbersVisible;
+
   /// Current mode of range selection.
   ///
   /// * `RangeSelectionMode.disabled` - range selection is always off.
@@ -246,6 +249,7 @@ class TableCalendar<T> extends StatefulWidget {
     this.enabledDayPredicate,
     this.selectedDayPredicate,
     this.holidayPredicate,
+    this.weekNumbersVisible = false,
     this.onRangeSelected,
     this.onDaySelected,
     this.onDayLongPressed,
@@ -504,6 +508,25 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
               _focusedDay.value = focusedDay;
               widget.onPageChanged?.call(focusedDay);
             },
+            weekNumbersVisible: widget.weekNumbersVisible,
+            weekNumberBuilder: (BuildContext context, DateTime day) {
+              final weekNumber = isoWeekNumber(day);
+              Widget? cell = widget.calendarBuilders.weekNumberBuilder
+                  ?.call(context, weekNumber);
+
+              if (cell == null) {
+                cell = Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 4),
+                  alignment: Alignment.center,
+                  child: Text(
+                    weekNumber.toString(),
+                    style: widget.calendarStyle.weekNumberTextStyle,
+                  ),
+                );
+              }
+
+              return cell;
+            },
             dowBuilder: (BuildContext context, DateTime day) {
               Widget? dowCell =
                   widget.calendarBuilders.dowBuilder?.call(context, day);
@@ -542,6 +565,19 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
         ),
       ],
     );
+  }
+
+  int isoWeekNumber(DateTime date) {
+    int daysToAdd = DateTime.thursday - date.weekday;
+    DateTime thursdayDate = daysToAdd > 0
+        ? date.add(Duration(days: daysToAdd))
+        : date.subtract(Duration(days: daysToAdd.abs()));
+    int dayOfYearThursday = dayOfYear(thursdayDate);
+    return 1 + ((dayOfYearThursday - 1) / 7).floor();
+  }
+
+  int dayOfYear(DateTime date) {
+    return date.difference(DateTime(date.year, 1, 1)).inDays;
   }
 
   Widget _buildCell(DateTime day, DateTime focusedDay) {

--- a/lib/src/table_calendar_base.dart
+++ b/lib/src/table_calendar_base.dart
@@ -14,6 +14,8 @@ class TableCalendarBase extends StatefulWidget {
   final CalendarFormat calendarFormat;
   final DayBuilder? dowBuilder;
   final FocusedDayBuilder dayBuilder;
+  final DayBuilder? weekNumberBuilder;
+  final bool weekNumbersVisible;
   final double? dowHeight;
   final double rowHeight;
   final bool sixWeekMonthsEnforced;
@@ -44,6 +46,8 @@ class TableCalendarBase extends StatefulWidget {
     required this.dayBuilder,
     this.dowHeight,
     required this.rowHeight,
+    this.weekNumberBuilder,
+    required this.weekNumbersVisible,
     this.sixWeekMonthsEnforced = false,
     this.dowVisible = true,
     this.dowDecoration,
@@ -217,6 +221,8 @@ class _TableCalendarBaseState extends State<TableCalendarBase>
               dowVisible: widget.dowVisible,
               dowHeight: widget.dowHeight,
               rowHeight: widget.rowHeight,
+              weekNumbersVisible: widget.weekNumbersVisible,
+              weekNumberBuilder: widget.weekNumberBuilder,
               dowDecoration: widget.dowDecoration,
               rowDecoration: widget.rowDecoration,
               tableBorder: widget.tableBorder,

--- a/lib/src/widgets/calendar_core.dart
+++ b/lib/src/widgets/calendar_core.dart
@@ -23,6 +23,8 @@ class CalendarCore extends StatelessWidget {
   final TableBorder? tableBorder;
   final double? dowHeight;
   final double? rowHeight;
+  final bool weekNumbersVisible;
+  final DayBuilder? weekNumberBuilder;
   final BoxConstraints constraints;
   final int? previousIndex;
   final StartingDayOfWeek startingDayOfWeek;
@@ -40,6 +42,8 @@ class CalendarCore extends StatelessWidget {
     required this.constraints,
     this.dowHeight,
     this.rowHeight,
+    this.weekNumberBuilder,
+    required this.weekNumbersVisible,
     this.startingDayOfWeek = StartingDayOfWeek.sunday,
     this.calendarFormat = CalendarFormat.month,
     this.pageController,
@@ -96,6 +100,14 @@ class CalendarCore extends StatelessWidget {
             return SizedBox(
               height: constrainedRowHeight ?? rowHeight,
               child: dayBuilder(context, day, baseDay),
+            );
+          },
+          dowHeight: dowHeight,
+          weekNumberVisible: weekNumbersVisible,
+          weekNumberBuilder: (context, day) {
+            return SizedBox(
+              height: constrainedRowHeight ?? rowHeight,
+              child: weekNumberBuilder?.call(context, day),
             );
           },
         );

--- a/lib/src/widgets/calendar_page.dart
+++ b/lib/src/widgets/calendar_page.dart
@@ -6,22 +6,29 @@ import 'package:flutter/widgets.dart';
 class CalendarPage extends StatelessWidget {
   final Widget Function(BuildContext context, DateTime day)? dowBuilder;
   final Widget Function(BuildContext context, DateTime day) dayBuilder;
+  final Widget Function(BuildContext context, DateTime day)? weekNumberBuilder;
   final List<DateTime> visibleDays;
   final Decoration? dowDecoration;
   final Decoration? rowDecoration;
   final TableBorder? tableBorder;
   final bool dowVisible;
+  final bool weekNumberVisible;
+  final double? dowHeight;
 
   const CalendarPage({
     Key? key,
     required this.visibleDays,
     this.dowBuilder,
     required this.dayBuilder,
+    this.weekNumberBuilder,
     this.dowDecoration,
     this.rowDecoration,
     this.tableBorder,
     this.dowVisible = true,
+    this.weekNumberVisible = false,
+    this.dowHeight,
   })  : assert(!dowVisible || dowBuilder != null),
+        assert(!weekNumberVisible || weekNumberBuilder != null),
         super(key: key);
 
   @override
@@ -38,10 +45,13 @@ class CalendarPage extends StatelessWidget {
   TableRow _buildDaysOfWeek(BuildContext context) {
     return TableRow(
       decoration: dowDecoration,
-      children: List.generate(
-        7,
-        (index) => dowBuilder!(context, visibleDays[index]),
-      ).toList(),
+      children: [
+        if (weekNumberVisible && dowVisible) SizedBox(height: dowHeight ?? 0),
+        ...List.generate(
+          7,
+          (index) => dowBuilder!(context, visibleDays[index]),
+        )
+      ].toList(),
     );
   }
 
@@ -51,10 +61,14 @@ class CalendarPage extends StatelessWidget {
     return List.generate(rowAmount, (index) => index * 7)
         .map((index) => TableRow(
               decoration: rowDecoration,
-              children: List.generate(
-                7,
-                (id) => dayBuilder(context, visibleDays[index + id]),
-              ),
+              children: [
+                if (weekNumberVisible)
+                  weekNumberBuilder!(context, visibleDays[index + 1]),
+                ...List.generate(
+                  7,
+                  (id) => dayBuilder(context, visibleDays[index + id]),
+                )
+              ],
             ))
         .toList();
   }

--- a/test/table_calendar_base_test.dart
+++ b/test/table_calendar_base_test.dart
@@ -26,6 +26,7 @@ void main() {
         await tester.pumpWidget(
           setupTestWidget(
             TableCalendarBase(
+              weekNumbersVisible: false,
               firstDay: DateTime.utc(2021, 5, 15),
               lastDay: DateTime.utc(2021, 8, 18),
               focusedDay: focusedDay,
@@ -72,6 +73,7 @@ void main() {
         await tester.pumpWidget(
           setupTestWidget(
             TableCalendarBase(
+              weekNumbersVisible: false,
               firstDay: DateTime.utc(2021, 5, 15),
               lastDay: DateTime.utc(2021, 8, 18),
               focusedDay: focusedDay,
@@ -118,6 +120,7 @@ void main() {
         await tester.pumpWidget(
           setupTestWidget(
             TableCalendarBase(
+              weekNumbersVisible: false,
               firstDay: DateTime.utc(2021, 5, 15),
               lastDay: DateTime.utc(2021, 8, 18),
               focusedDay: focusedDay,
@@ -164,6 +167,7 @@ void main() {
         await tester.pumpWidget(
           setupTestWidget(
             TableCalendarBase(
+              weekNumbersVisible: false,
               firstDay: DateTime.utc(2021, 5, 15),
               lastDay: DateTime.utc(2021, 8, 18),
               focusedDay: focusedDay,
@@ -210,6 +214,7 @@ void main() {
         await tester.pumpWidget(
           setupTestWidget(
             TableCalendarBase(
+              weekNumbersVisible: false,
               firstDay: DateTime.utc(2021, 5, 15),
               lastDay: DateTime.utc(2021, 8, 18),
               focusedDay: focusedDay,
@@ -256,6 +261,7 @@ void main() {
         await tester.pumpWidget(
           setupTestWidget(
             TableCalendarBase(
+              weekNumbersVisible: false,
               firstDay: DateTime.utc(2021, 5, 15),
               lastDay: DateTime.utc(2021, 8, 18),
               focusedDay: focusedDay,
@@ -307,6 +313,7 @@ void main() {
       await tester.pumpWidget(
         setupTestWidget(
           TableCalendarBase(
+            weekNumbersVisible: false,
             firstDay: DateTime.utc(2021, 5, 15),
             lastDay: DateTime.utc(2021, 8, 18),
             focusedDay: focusedDay,
@@ -358,6 +365,7 @@ void main() {
         await tester.pumpWidget(
           setupTestWidget(
             TableCalendarBase(
+              weekNumbersVisible: false,
               firstDay: DateTime.utc(2021, 5, 15),
               lastDay: DateTime.utc(2021, 8, 18),
               focusedDay: DateTime.utc(2021, 7, 15),


### PR DESCRIPTION
It's worth noting that the week numbers can be wrong if startingDayOfWeek isn't Monday. This is because the algorithm used follows the ISO 8601 standard which defines weeks as starting with Monday