### PR TITLE
Add customizable left and right header button builders.

### DIFF
--- a/lib/src/customization/calendar_builders.dart
+++ b/lib/src/customization/calendar_builders.dart
@@ -75,8 +75,22 @@ class CalendarBuilders<T> {
   /// Custom builder for days of the week labels (Mon, Tue, Wed, etc.).
   final DayBuilder? dowBuilder;
 
-  /// Use to customize header's title using different widget
+  /// Use to customize header's title using different widget.
   final DayBuilder? headerTitleBuilder;
+
+  /// Use to customize the left-hand button shown in the header using a
+  /// different widget.
+  ///
+  /// Exposes the callback provided by the calender to navigate to the previous
+  /// available page.
+  final Widget? Function(GestureTapCallback onTap)? headerLeftButtonBuilder;
+
+  /// Use to customize the right-hand button shown in the header using a
+  /// different widget.
+  ///
+  /// Exposes the callback provided by the calender to navigate to the next
+  /// available page.
+  final Widget? Function(GestureTapCallback onTap)? headerRightButtonBuilder;
 
   /// Creates `CalendarBuilders` for `TableCalendar` widget.
   const CalendarBuilders({
@@ -95,5 +109,7 @@ class CalendarBuilders<T> {
     this.markerBuilder,
     this.dowBuilder,
     this.headerTitleBuilder,
+    this.headerLeftButtonBuilder,
+    this.headerRightButtonBuilder,
   });
 }

--- a/lib/src/customization/calendar_builders.dart
+++ b/lib/src/customization/calendar_builders.dart
@@ -81,14 +81,14 @@ class CalendarBuilders<T> {
   /// Use to customize the left-hand button shown in the header using a
   /// different widget.
   ///
-  /// Exposes the callback provided by the calender to navigate to the previous
+  /// Exposes the callback provided by the calendar to navigate to the previous
   /// available page.
   final Widget? Function(GestureTapCallback onTap)? headerLeftButtonBuilder;
 
   /// Use to customize the right-hand button shown in the header using a
   /// different widget.
   ///
-  /// Exposes the callback provided by the calender to navigate to the next
+  /// Exposes the callback provided by the calendar to navigate to the next
   /// available page.
   final Widget? Function(GestureTapCallback onTap)? headerRightButtonBuilder;
 

--- a/lib/src/table_calendar.dart
+++ b/lib/src/table_calendar.dart
@@ -451,6 +451,10 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
             builder: (context, value, _) {
               return CalendarHeader(
                 headerTitleBuilder: widget.calendarBuilders.headerTitleBuilder,
+                headerLeftButtonBuilder:
+                    widget.calendarBuilders.headerLeftButtonBuilder,
+                headerRightButtonBuilder:
+                    widget.calendarBuilders.headerRightButtonBuilder,
                 focusedMonth: value,
                 onLeftChevronTap: _onLeftChevronTap,
                 onRightChevronTap: _onRightChevronTap,

--- a/lib/src/widgets/calendar_header.dart
+++ b/lib/src/widgets/calendar_header.dart
@@ -21,6 +21,8 @@ class CalendarHeader extends StatelessWidget {
   final ValueChanged<CalendarFormat> onFormatButtonTap;
   final Map<CalendarFormat, String> availableCalendarFormats;
   final DayBuilder? headerTitleBuilder;
+  final Widget? Function(GestureTapCallback onTap)? headerLeftButtonBuilder;
+  final Widget? Function(GestureTapCallback onTap)? headerRightButtonBuilder;
 
   const CalendarHeader({
     Key? key,
@@ -35,6 +37,8 @@ class CalendarHeader extends StatelessWidget {
     required this.onFormatButtonTap,
     required this.availableCalendarFormats,
     this.headerTitleBuilder,
+    this.headerLeftButtonBuilder,
+    this.headerRightButtonBuilder,
   }) : super(key: key);
 
   @override
@@ -50,12 +54,13 @@ class CalendarHeader extends StatelessWidget {
         mainAxisSize: MainAxisSize.max,
         children: [
           if (headerStyle.leftChevronVisible)
-            CustomIconButton(
-              icon: headerStyle.leftChevronIcon,
-              onTap: onLeftChevronTap,
-              margin: headerStyle.leftChevronMargin,
-              padding: headerStyle.leftChevronPadding,
-            ),
+            headerLeftButtonBuilder?.call(onLeftChevronTap) ??
+                CustomIconButton(
+                  icon: headerStyle.leftChevronIcon,
+                  onTap: onLeftChevronTap,
+                  margin: headerStyle.leftChevronMargin,
+                  padding: headerStyle.leftChevronPadding,
+                ),
           Expanded(
             child: headerTitleBuilder?.call(context, focusedMonth) ??
                 GestureDetector(
@@ -85,12 +90,13 @@ class CalendarHeader extends StatelessWidget {
               ),
             ),
           if (headerStyle.rightChevronVisible)
-            CustomIconButton(
-              icon: headerStyle.rightChevronIcon,
-              onTap: onRightChevronTap,
-              margin: headerStyle.rightChevronMargin,
-              padding: headerStyle.rightChevronPadding,
-            ),
+            headerRightButtonBuilder?.call(onRightChevronTap) ??
+                CustomIconButton(
+                  icon: headerStyle.rightChevronIcon,
+                  onTap: onRightChevronTap,
+                  margin: headerStyle.rightChevronMargin,
+                  padding: headerStyle.rightChevronPadding,
+                ),
         ],
       ),
     );


### PR DESCRIPTION
The ability to use the built-in calendar header but customize the left and right navigation buttons using builder callbacks does not seem to be supported, even though the ability to customize the header title in the same way **is** supported. It's also worth noting that the default buttons (`CustomIconButton`) use an `InkWell` for hit detection, meaning that the built-in calendar header and its API cannot be used without also rendering an `InkSplash` when either navigation button is tapped.

This adds the option to pass custom builders for the right and left header navigation buttons to `CalendarBuilders`. This will allow the use of the built-in calendar header and its API in a wider variety of UI designs.