### PR TITLE
Add Table Padding

### DIFF
--- a/lib/src/customization/calendar_style.dart
+++ b/lib/src/customization/calendar_style.dart
@@ -145,6 +145,9 @@ class CalendarStyle {
   /// Border for the internal `Table` widget.
   final TableBorder tableBorder;
 
+  /// Padding for the internal `Table` widget.
+  final EdgeInsets tablePadding;
+
   /// Creates a `CalendarStyle` used by `TableCalendar` widget.
   const CalendarStyle({
     this.isTodayHighlighted = true,
@@ -218,6 +221,7 @@ class CalendarStyle {
     this.defaultDecoration = const BoxDecoration(shape: BoxShape.circle),
     this.rowDecoration = const BoxDecoration(),
     this.tableBorder = const TableBorder(),
+    this.tablePadding = const EdgeInsets.all(0),
   });
 }
 

--- a/lib/src/table_calendar.dart
+++ b/lib/src/table_calendar.dart
@@ -488,6 +488,7 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
             dowDecoration: widget.daysOfWeekStyle.decoration,
             rowDecoration: widget.calendarStyle.rowDecoration,
             tableBorder: widget.calendarStyle.tableBorder,
+            tablePadding: widget.calendarStyle.tablePadding,
             dowVisible: widget.daysOfWeekVisible,
             dowHeight: widget.daysOfWeekHeight,
             rowHeight: widget.rowHeight,

--- a/lib/src/table_calendar_base.dart
+++ b/lib/src/table_calendar_base.dart
@@ -21,6 +21,7 @@ class TableCalendarBase extends StatefulWidget {
   final Decoration? dowDecoration;
   final Decoration? rowDecoration;
   final TableBorder? tableBorder;
+  final EdgeInsets? tablePadding;
   final Duration formatAnimationDuration;
   final Curve formatAnimationCurve;
   final bool pageAnimationEnabled;
@@ -49,6 +50,7 @@ class TableCalendarBase extends StatefulWidget {
     this.dowDecoration,
     this.rowDecoration,
     this.tableBorder,
+    this.tablePadding,
     this.formatAnimationDuration = const Duration(milliseconds: 200),
     this.formatAnimationCurve = Curves.linear,
     this.pageAnimationEnabled = true,
@@ -218,6 +220,7 @@ class _TableCalendarBaseState extends State<TableCalendarBase> {
               dowDecoration: widget.dowDecoration,
               rowDecoration: widget.rowDecoration,
               tableBorder: widget.tableBorder,
+              tablePadding: widget.tablePadding,
               onPageChanged: (index, focusedMonth) {
                 if (!_pageCallbackDisabled) {
                   if (!isSameDay(_focusedDay, focusedMonth)) {
@@ -250,8 +253,9 @@ class _TableCalendarBaseState extends State<TableCalendarBase> {
   }
 
   double _getPageHeight(int rowCount) {
+    final tablePaddingHeight = widget.tablePadding?.vertical ?? 0.0;
     final dowHeight = widget.dowVisible ? widget.dowHeight! : 0.0;
-    return dowHeight + rowCount * widget.rowHeight;
+    return dowHeight + rowCount * widget.rowHeight + tablePaddingHeight;
   }
 
   int _calculateFocusedPage(

--- a/lib/src/widgets/calendar_core.dart
+++ b/lib/src/widgets/calendar_core.dart
@@ -21,6 +21,7 @@ class CalendarCore extends StatelessWidget {
   final Decoration? dowDecoration;
   final Decoration? rowDecoration;
   final TableBorder? tableBorder;
+  final EdgeInsets? tablePadding;
   final double? dowHeight;
   final double? rowHeight;
   final BoxConstraints constraints;
@@ -50,6 +51,7 @@ class CalendarCore extends StatelessWidget {
     this.dowDecoration,
     this.rowDecoration,
     this.tableBorder,
+    this.tablePadding,
     this.scrollPhysics,
   })  : assert(!dowVisible || (dowHeight != null && dowBuilder != null)),
         super(key: key);
@@ -77,6 +79,7 @@ class CalendarCore extends StatelessWidget {
           dowDecoration: dowDecoration,
           rowDecoration: rowDecoration,
           tableBorder: tableBorder,
+          tablePadding: tablePadding,
           dowBuilder: (context, day) {
             return SizedBox(
               height: dowHeight,

--- a/lib/src/widgets/calendar_page.dart
+++ b/lib/src/widgets/calendar_page.dart
@@ -10,6 +10,7 @@ class CalendarPage extends StatelessWidget {
   final Decoration? dowDecoration;
   final Decoration? rowDecoration;
   final TableBorder? tableBorder;
+  final EdgeInsets? tablePadding;
   final bool dowVisible;
 
   const CalendarPage({
@@ -20,18 +21,22 @@ class CalendarPage extends StatelessWidget {
     this.dowDecoration,
     this.rowDecoration,
     this.tableBorder,
+    this.tablePadding,
     this.dowVisible = true,
   })  : assert(!dowVisible || dowBuilder != null),
         super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Table(
-      border: tableBorder,
-      children: [
-        if (dowVisible) _buildDaysOfWeek(context),
-        ..._buildCalendarDays(context),
-      ],
+    return Padding(
+      padding: tablePadding ?? EdgeInsets.zero,
+      child: Table(
+        border: tableBorder,
+        children: [
+          if (dowVisible) _buildDaysOfWeek(context),
+          ..._buildCalendarDays(context),
+        ],
+      ),
     );
   }
 


### PR DESCRIPTION
Hello.
Thank you for the good package.


I needed to add a border to the calendar table. However, I could not set padding on the tables, so each table was displayed sticking to each other.
So I changed it to be able to set tablePadding by referring to the tableBorder parameter.

![table_calender](https://user-images.githubusercontent.com/17955947/178888149-3a6b9a54-c384-480f-b36c-721b7d2d3c97.gif)

