### PR TITLE
theme using ThemeExtension

### DIFF
--- a/example/lib/pages/events_example.dart
+++ b/example/lib/pages/events_example.dart
@@ -90,34 +90,39 @@ class _TableEventsExampleState extends State<TableEventsExample> {
       ),
       body: Column(
         children: [
-          TableCalendar<Event>(
-            firstDay: kFirstDay,
-            lastDay: kLastDay,
-            focusedDay: _focusedDay,
-            selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
-            rangeStartDay: _rangeStart,
-            rangeEndDay: _rangeEnd,
-            calendarFormat: _calendarFormat,
-            rangeSelectionMode: _rangeSelectionMode,
-            eventLoader: _getEventsForDay,
-            startingDayOfWeek: StartingDayOfWeek.monday,
-            calendarStyle: CalendarStyle(
-              // Use `CalendarStyle` to customize the UI
-              outsideDaysVisible: false,
-            ),
-            onDaySelected: _onDaySelected,
-            onRangeSelected: _onRangeSelected,
-            onFormatChanged: (format) {
-              if (_calendarFormat != format) {
-                setState(() {
-                  _calendarFormat = format;
-                });
-              }
-            },
-            onPageChanged: (focusedDay) {
-              _focusedDay = focusedDay;
-            },
-          ),
+          Theme(
+              data: ThemeData(
+                extensions: [
+                  CalendarStyle(
+                    // Use `CalendarStyle` to customize the UI
+                    outsideDaysVisible: false,
+                  )
+                ],
+              ),
+              child: TableCalendar<Event>(
+                firstDay: kFirstDay,
+                lastDay: kLastDay,
+                focusedDay: _focusedDay,
+                selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
+                rangeStartDay: _rangeStart,
+                rangeEndDay: _rangeEnd,
+                calendarFormat: _calendarFormat,
+                rangeSelectionMode: _rangeSelectionMode,
+                eventLoader: _getEventsForDay,
+                startingDayOfWeek: StartingDayOfWeek.monday,
+                onDaySelected: _onDaySelected,
+                onRangeSelected: _onRangeSelected,
+                onFormatChanged: (format) {
+                  if (_calendarFormat != format) {
+                    setState(() {
+                      _calendarFormat = format;
+                    });
+                  }
+                },
+                onPageChanged: (focusedDay) {
+                  _focusedDay = focusedDay;
+                },
+              )),
           const SizedBox(height: 8.0),
           Expanded(
             child: ValueListenableBuilder<List<Event>>(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,49 +5,56 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      url: "https://pub.dartlang.org"
+      sha256: caac504f942f41dfadcf45229ce8c47065b93919a12739f20d6173a883c5ec73
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   flutter:
@@ -64,42 +71,56 @@ packages:
     dependency: transitive
     description:
       name: intl
-      url: "https://pub.dartlang.org"
+      sha256: a3715e3bc90294e971cb7dc063fbf3cd9ee0ebf8604ffeafabd9e6f16abbdbe6
+      url: "https://pub.dev"
     source: hosted
     version: "0.18.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.5"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.2"
   simple_gesture_detector:
     dependency: transitive
     description:
       name: simple_gesture_detector
-      url: "https://pub.dartlang.org"
+      sha256: "86d08f85f1f58583b7b4b941d989f48ea6ce08c1724a1d10954a277c2ec36592"
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
   sky_engine:
@@ -111,30 +132,34 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   table_calendar:
     dependency: "direct main"
     description:
@@ -146,23 +171,26 @@ packages:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.16"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
-  flutter: ">=1.17.0"
+  dart: ">=2.18.0 <3.0.0"
+  flutter: ">=3.0.0"

--- a/lib/src/customization/calendar_style.dart
+++ b/lib/src/customization/calendar_style.dart
@@ -1,10 +1,13 @@
 // Copyright 2019 Aleksander Woźniak
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:flutter/widgets.dart';
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
 
 /// Class containing styling and configuration for `TableCalendar`'s content.
-class CalendarStyle {
+@immutable
+class CalendarStyle extends ThemeExtension<CalendarStyle> {
   /// Maximum amount of single event marker dots to be displayed.
   final int markersMaxCount;
 
@@ -228,6 +231,171 @@ class CalendarStyle {
     this.tableBorder = const TableBorder(),
     this.tablePadding = const EdgeInsets.all(0),
   });
+
+  @override
+  ThemeExtension<CalendarStyle> copyWith({
+    int? markersMaxCount,
+    bool? canMarkersOverflow,
+    bool? markersAutoAligned,
+    double? markersAnchor,
+    double? markerSize,
+    double? markerSizeScale,
+    PositionedOffset? markersOffset,
+    AlignmentGeometry? markersAlignment,
+    Decoration? markerDecoration,
+    EdgeInsets? markerMargin,
+    EdgeInsets? cellMargin,
+    EdgeInsets? cellPadding,
+    AlignmentGeometry? cellAlignment,
+    double? rangeHighlightScale,
+    Color? rangeHighlightColor,
+    bool? outsideDaysVisible,
+    bool? isTodayHighlighted,
+    TextStyle? todayTextStyle,
+    Decoration? todayDecoration,
+    TextStyle? selectedTextStyle,
+    Decoration? selectedDecoration,
+    TextStyle? rangeStartTextStyle,
+    Decoration? rangeStartDecoration,
+    TextStyle? rangeEndTextStyle,
+    Decoration? rangeEndDecoration,
+    TextStyle? withinRangeTextStyle,
+    Decoration? withinRangeDecoration,
+    TextStyle? outsideTextStyle,
+    Decoration? outsideDecoration,
+    TextStyle? disabledTextStyle,
+    Decoration? disabledDecoration,
+    TextStyle? holidayTextStyle,
+    Decoration? holidayDecoration,
+    TextStyle? weekendTextStyle,
+    Decoration? weekendDecoration,
+    TextStyle? weekNumberTextStyle,
+    TextStyle? defaultTextStyle,
+    Decoration? defaultDecoration,
+    Decoration? rowDecoration,
+    TableBorder? tableBorder,
+    EdgeInsets? tablePadding,
+  }) {
+    return CalendarStyle(
+      markersMaxCount: markersMaxCount ?? this.markersMaxCount,
+      canMarkersOverflow: canMarkersOverflow ?? this.canMarkersOverflow,
+      markersAutoAligned: markersAutoAligned ?? this.markersAutoAligned,
+      markersAnchor: markersAnchor ?? this.markersAnchor,
+      markerSize: markerSize ?? this.markerSize,
+      markerSizeScale: markerSizeScale ?? this.markerSizeScale,
+      markersOffset: markersOffset ?? this.markersOffset,
+      markersAlignment: markersAlignment ?? this.markersAlignment,
+      markerDecoration: markerDecoration ?? this.markerDecoration,
+      markerMargin: markerMargin ?? this.markerMargin,
+      cellMargin: cellMargin ?? this.cellMargin,
+      cellPadding: cellPadding ?? this.cellPadding,
+      cellAlignment: cellAlignment ?? this.cellAlignment,
+      rangeHighlightScale: rangeHighlightScale ?? this.rangeHighlightScale,
+      rangeHighlightColor: rangeHighlightColor ?? this.rangeHighlightColor,
+      outsideDaysVisible: outsideDaysVisible ?? this.outsideDaysVisible,
+      isTodayHighlighted: isTodayHighlighted ?? this.isTodayHighlighted,
+      todayTextStyle: todayTextStyle ?? this.todayTextStyle,
+      todayDecoration: todayDecoration ?? this.todayDecoration,
+      selectedTextStyle: selectedTextStyle ?? this.selectedTextStyle,
+      selectedDecoration: selectedDecoration ?? this.selectedDecoration,
+      rangeStartTextStyle: rangeStartTextStyle ?? this.rangeStartTextStyle,
+      rangeStartDecoration: rangeStartDecoration ?? this.rangeStartDecoration,
+      rangeEndTextStyle: rangeEndTextStyle ?? this.rangeEndTextStyle,
+      rangeEndDecoration: rangeEndDecoration ?? this.rangeEndDecoration,
+      withinRangeTextStyle: withinRangeTextStyle ?? this.withinRangeTextStyle,
+      withinRangeDecoration:
+          withinRangeDecoration ?? this.withinRangeDecoration,
+      outsideTextStyle: outsideTextStyle ?? this.outsideTextStyle,
+      outsideDecoration: outsideDecoration ?? this.outsideDecoration,
+      disabledTextStyle: disabledTextStyle ?? this.disabledTextStyle,
+      disabledDecoration: disabledDecoration ?? this.disabledDecoration,
+      holidayTextStyle: holidayTextStyle ?? this.holidayTextStyle,
+      holidayDecoration: holidayDecoration ?? this.holidayDecoration,
+      weekendTextStyle: weekendTextStyle ?? this.weekendTextStyle,
+      weekendDecoration: weekendDecoration ?? this.weekendDecoration,
+      weekNumberTextStyle: weekNumberTextStyle ?? this.weekNumberTextStyle,
+      defaultTextStyle: defaultTextStyle ?? this.defaultTextStyle,
+      defaultDecoration: defaultDecoration ?? this.defaultDecoration,
+      rowDecoration: rowDecoration ?? this.rowDecoration,
+      tableBorder: tableBorder ?? this.tableBorder,
+      tablePadding: tablePadding ?? this.tablePadding,
+    );
+  }
+
+  @override
+  ThemeExtension<CalendarStyle> lerp(
+    covariant ThemeExtension<CalendarStyle>? other,
+    double t,
+  ) {
+    if (other is! CalendarStyle) {
+      return this;
+    }
+
+    return this.copyWith(
+      markersAnchor: lerpDouble(markersAnchor, other.markersAnchor, t),
+      markerSize: lerpDouble(markerSize, other.markerSize, t),
+      markerSizeScale: lerpDouble(markerSizeScale, other.markerSizeScale, t),
+      markersOffset:
+          PositionedOffset.lerp(markersOffset, other.markersOffset, t),
+      markersAlignment:
+          AlignmentGeometry.lerp(markersAlignment, other.markersAlignment, t),
+      markerDecoration:
+          Decoration.lerp(markerDecoration, other.markerDecoration, t),
+      markerMargin: EdgeInsets.lerp(markerMargin, other.markerMargin, t),
+      cellMargin: EdgeInsets.lerp(cellMargin, other.cellMargin, t),
+      cellPadding: EdgeInsets.lerp(cellPadding, other.cellPadding, t),
+      cellAlignment:
+          AlignmentGeometry.lerp(cellAlignment, other.cellAlignment, t),
+      rangeHighlightScale:
+          lerpDouble(rangeHighlightScale, other.rangeHighlightScale, t),
+      rangeHighlightColor:
+          Color.lerp(rangeHighlightColor, other.rangeHighlightColor, t),
+      todayTextStyle: TextStyle.lerp(todayTextStyle, other.todayTextStyle, t),
+      todayDecoration:
+          Decoration.lerp(todayDecoration, other.todayDecoration, t),
+      selectedTextStyle:
+          TextStyle.lerp(selectedTextStyle, other.selectedTextStyle, t),
+      selectedDecoration:
+          Decoration.lerp(selectedDecoration, other.selectedDecoration, t),
+      rangeStartTextStyle:
+          TextStyle.lerp(rangeStartTextStyle, other.rangeStartTextStyle, t),
+      rangeStartDecoration:
+          Decoration.lerp(rangeStartDecoration, other.rangeStartDecoration, t),
+      rangeEndTextStyle:
+          TextStyle.lerp(rangeEndTextStyle, other.rangeEndTextStyle, t),
+      rangeEndDecoration:
+          Decoration.lerp(rangeEndDecoration, other.rangeEndDecoration, t),
+      withinRangeTextStyle:
+          TextStyle.lerp(withinRangeTextStyle, other.withinRangeTextStyle, t),
+      withinRangeDecoration: Decoration.lerp(
+          withinRangeDecoration, other.withinRangeDecoration, t),
+      outsideTextStyle:
+          TextStyle.lerp(outsideTextStyle, other.outsideTextStyle, t),
+      outsideDecoration:
+          Decoration.lerp(outsideDecoration, other.outsideDecoration, t),
+      disabledTextStyle:
+          TextStyle.lerp(disabledTextStyle, other.disabledTextStyle, t),
+      disabledDecoration:
+          Decoration.lerp(disabledDecoration, other.disabledDecoration, t),
+      holidayTextStyle:
+          TextStyle.lerp(holidayTextStyle, other.holidayTextStyle, t),
+      holidayDecoration:
+          Decoration.lerp(holidayDecoration, other.holidayDecoration, t),
+      weekendTextStyle:
+          TextStyle.lerp(weekendTextStyle, other.weekendTextStyle, t),
+      weekendDecoration:
+          Decoration.lerp(weekendDecoration, other.weekendDecoration, t),
+      weekNumberTextStyle:
+          TextStyle.lerp(weekNumberTextStyle, other.weekNumberTextStyle, t),
+      defaultTextStyle:
+          TextStyle.lerp(defaultTextStyle, other.defaultTextStyle, t),
+      defaultDecoration:
+          Decoration.lerp(defaultDecoration, other.defaultDecoration, t),
+      rowDecoration: Decoration.lerp(rowDecoration, other.rowDecoration, t),
+      tableBorder: TableBorder.lerp(tableBorder, other.tableBorder, t),
+      tablePadding: EdgeInsets.lerp(tablePadding, other.tablePadding, t),
+    );
+  }
 }
 
 /// Helper class containing data for internal `Positioned` widget.
@@ -246,4 +414,21 @@ class PositionedOffset {
 
   /// Creates a `PositionedOffset`. Values are set to `null` by default.
   const PositionedOffset({this.top, this.bottom, this.start, this.end});
+
+  static PositionedOffset? lerp(
+    PositionedOffset? a,
+    PositionedOffset? b,
+    double t,
+  ) {
+    if (a == null && b == null) {
+      return null;
+    }
+
+    return PositionedOffset(
+      top: lerpDouble(a?.top, b?.top, t),
+      bottom: lerpDouble(a?.bottom, b?.bottom, t),
+      start: lerpDouble(a?.start, b?.start, t),
+      end: lerpDouble(a?.end, b?.end, t),
+    );
+  }
 }

--- a/lib/src/table_calendar.dart
+++ b/lib/src/table_calendar.dart
@@ -3,7 +3,7 @@
 
 import 'dart:math';
 
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:simple_gesture_detector/simple_gesture_detector.dart';
 
@@ -147,7 +147,10 @@ class TableCalendar<T> extends StatefulWidget {
   final DaysOfWeekStyle daysOfWeekStyle;
 
   /// Style for `TableCalendar`'s content.
-  final CalendarStyle calendarStyle;
+  /// 
+  /// If not specified the closest surrounding [CalendarStyle] will be used.
+  /// If there isn't one a new one will be created.
+  final CalendarStyle? calendarStyle;
 
   /// Set of custom builders for `TableCalendar` to work with.
   /// Use those to fully tailor the UI.
@@ -243,7 +246,7 @@ class TableCalendar<T> extends StatefulWidget {
     ),
     this.headerStyle = const HeaderStyle(),
     this.daysOfWeekStyle = const DaysOfWeekStyle(),
-    this.calendarStyle = const CalendarStyle(),
+    this.calendarStyle,
     this.calendarBuilders = const CalendarBuilders(),
     this.rangeSelectionMode = RangeSelectionMode.toggledOff,
     this.eventLoader,
@@ -312,6 +315,11 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
     super.dispose();
   }
 
+  CalendarStyle get _calendarStyle =>
+      widget.calendarStyle ??
+      Theme.of(context).extension<CalendarStyle>() ??
+      const CalendarStyle();
+
   bool get _isRangeSelectionToggleable =>
       _rangeSelectionMode == RangeSelectionMode.toggledOn ||
       _rangeSelectionMode == RangeSelectionMode.toggledOff;
@@ -321,7 +329,7 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
       _rangeSelectionMode == RangeSelectionMode.enforced;
 
   bool get _shouldBlockOutsideDays =>
-      !widget.calendarStyle.outsideDaysVisible &&
+      !_calendarStyle.outsideDaysVisible &&
       widget.calendarFormat == CalendarFormat.month;
 
   void _swipeCalendarFormat(SwipeDirection direction) {
@@ -490,9 +498,9 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
             lastDay: widget.lastDay,
             startingDayOfWeek: widget.startingDayOfWeek,
             dowDecoration: widget.daysOfWeekStyle.decoration,
-            rowDecoration: widget.calendarStyle.rowDecoration,
-            tableBorder: widget.calendarStyle.tableBorder,
-            tablePadding: widget.calendarStyle.tablePadding,
+            rowDecoration: _calendarStyle.rowDecoration,
+            tableBorder: _calendarStyle.tableBorder,
+            tablePadding: _calendarStyle.tablePadding,
             dowVisible: widget.daysOfWeekVisible,
             dowHeight: widget.daysOfWeekHeight,
             rowHeight: widget.rowHeight,
@@ -521,7 +529,7 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
                   child: Center(
                     child: Text(
                       weekNumber.toString(),
-                      style: widget.calendarStyle.weekNumberTextStyle,
+                      style: _calendarStyle.weekNumberTextStyle,
                     ),
                   ),
                 );
@@ -602,10 +610,9 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
                   start: isRangeStart ? constraints.maxWidth * 0.5 : 0.0,
                   end: isRangeEnd ? constraints.maxWidth * 0.5 : 0.0,
                 ),
-                height:
-                    (shorterSide - widget.calendarStyle.cellMargin.vertical) *
-                        widget.calendarStyle.rangeHighlightScale,
-                color: widget.calendarStyle.rangeHighlightColor,
+                height: (shorterSide - _calendarStyle.cellMargin.vertical) *
+                    _calendarStyle.rangeHighlightScale,
+                color: _calendarStyle.rangeHighlightColor,
               ),
             );
           }
@@ -623,9 +630,9 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
           key: ValueKey('CellContent-${day.year}-${day.month}-${day.day}'),
           day: day,
           focusedDay: focusedDay,
-          calendarStyle: widget.calendarStyle,
+          calendarStyle: _calendarStyle,
           calendarBuilders: widget.calendarBuilders,
-          isTodayHighlighted: widget.calendarStyle.isTodayHighlighted,
+          isTodayHighlighted: _calendarStyle.isTodayHighlighted,
           isToday: isToday,
           isSelected: widget.selectedDayPredicate?.call(day) ?? false,
           isRangeStart: isRangeStart,
@@ -648,31 +655,31 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
           if (events.isNotEmpty && markerWidget == null) {
             final center = constraints.maxHeight / 2;
 
-            final markerSize = widget.calendarStyle.markerSize ??
-                (shorterSide - widget.calendarStyle.cellMargin.vertical) *
-                    widget.calendarStyle.markerSizeScale;
+            final markerSize = _calendarStyle.markerSize ??
+                (shorterSide - _calendarStyle.cellMargin.vertical) *
+                    _calendarStyle.markerSizeScale;
 
             final markerAutoAlignmentTop = center +
-                (shorterSide - widget.calendarStyle.cellMargin.vertical) / 2 -
-                (markerSize * widget.calendarStyle.markersAnchor);
+                (shorterSide - _calendarStyle.cellMargin.vertical) / 2 -
+                (markerSize * _calendarStyle.markersAnchor);
 
             markerWidget = PositionedDirectional(
-              top: widget.calendarStyle.markersAutoAligned
+              top: _calendarStyle.markersAutoAligned
                   ? markerAutoAlignmentTop
-                  : widget.calendarStyle.markersOffset.top,
-              bottom: widget.calendarStyle.markersAutoAligned
+                  : _calendarStyle.markersOffset.top,
+              bottom: _calendarStyle.markersAutoAligned
                   ? null
-                  : widget.calendarStyle.markersOffset.bottom,
-              start: widget.calendarStyle.markersAutoAligned
+                  : _calendarStyle.markersOffset.bottom,
+              start: _calendarStyle.markersAutoAligned
                   ? null
-                  : widget.calendarStyle.markersOffset.start,
-              end: widget.calendarStyle.markersAutoAligned
+                  : _calendarStyle.markersOffset.start,
+              end: _calendarStyle.markersAutoAligned
                   ? null
-                  : widget.calendarStyle.markersOffset.end,
+                  : _calendarStyle.markersOffset.end,
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: events
-                    .take(widget.calendarStyle.markersMaxCount)
+                    .take(_calendarStyle.markersMaxCount)
                     .map((event) => _buildSingleMarker(day, event, markerSize))
                     .toList(),
               ),
@@ -685,11 +692,10 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
         }
 
         return Stack(
-          alignment: widget.calendarStyle.markersAlignment,
+          alignment: _calendarStyle.markersAlignment,
           children: children,
-          clipBehavior: widget.calendarStyle.canMarkersOverflow
-              ? Clip.none
-              : Clip.hardEdge,
+          clipBehavior:
+              _calendarStyle.canMarkersOverflow ? Clip.none : Clip.hardEdge,
         );
       },
     );
@@ -701,8 +707,8 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
         Container(
           width: markerSize,
           height: markerSize,
-          margin: widget.calendarStyle.markerMargin,
-          decoration: widget.calendarStyle.markerDecoration,
+          margin: _calendarStyle.markerMargin,
+          decoration: _calendarStyle.markerDecoration,
         );
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,42 +5,48 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   flutter:
@@ -57,42 +63,56 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      url: "https://pub.dartlang.org"
+      sha256: a3715e3bc90294e971cb7dc063fbf3cd9ee0ebf8604ffeafabd9e6f16abbdbe6
+      url: "https://pub.dev"
     source: hosted
     version: "0.18.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.5"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.2"
   simple_gesture_detector:
     dependency: "direct main"
     description:
       name: simple_gesture_detector
-      url: "https://pub.dartlang.org"
+      sha256: "86d08f85f1f58583b7b4b941d989f48ea6ce08c1724a1d10954a277c2ec36592"
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
   sky_engine:
@@ -104,51 +124,58 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.16"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
-  flutter: ">=1.17.0"
+  dart: ">=2.18.0 <3.0.0"
+  flutter: ">=3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/aleksanderwozniak/table_calendar
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.17.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Let the `CalendarStyle` extend the `ThemeExtension` introduced in flutter 3.

Yes this raises the minimum required flutter version to version 3.

Why?
Having a theme extension lets us listen to the closest ancestor by using `Theme.of(context)` similar to how built in widgets do. This lets consumers of this library define the style in thier global `ThemeData` cleaning up thier code.

This does not break the existing api.