### PR TITLE
Enhance that user can mark 'today' as String.

### DIFF
--- a/lib/src/customization/calendar_style.dart
+++ b/lib/src/customization/calendar_style.dart
@@ -74,6 +74,9 @@ class CalendarStyle {
   /// TextStyle for a day cell that matches the current day.
   final TextStyle todayTextStyle;
 
+  /// Alternative text to express today instead of numbers
+  final String? todayText;
+
   /// Decoration for a day cell that matches the current day.
   final Decoration todayDecoration;
 
@@ -177,6 +180,7 @@ class CalendarStyle {
       color: const Color(0xFFFAFAFA),
       fontSize: 16.0,
     ), //
+    this.todayText,
     this.todayDecoration = const BoxDecoration(
       color: const Color(0xFF9FA8DA),
       shape: BoxShape.circle,

--- a/lib/src/widgets/cell_content.dart
+++ b/lib/src/widgets/cell_content.dart
@@ -60,7 +60,10 @@ class CellContent extends StatelessWidget {
       );
     }
 
-    final text = '${day.day}';
+    final dayString = day.day.toString();
+    final text = isToday
+        ? calendarStyle.todayText ?? dayString
+        : dayString;
     final margin = calendarStyle.cellMargin;
     final padding = calendarStyle.cellPadding;
     final alignment = calendarStyle.cellAlignment;


### PR DESCRIPTION
Thank you for your wonderful calendar.

Designer wants to show String instead of number if it's "today." 
Because this feature doesn't exist, So I added a nullable property called todayText to CalendarStyle.

The code and screenshot below are what appears when apply CalenderStyle with todayText to the basics_example.dart.

I simply added todayText, but in fact, when the user uses todayText without setting the todayTextStyle, It looks better to adjust the fontSize only to 12 in the default todayTextStyle.
But to do that, I have to use the initializer of constructor, but you don't seem to want that pattern, so I didn't apply that part.

If you like this feature but you think I need to improve the code so you put it on hold, let me know!

<img width="237" alt="image" src="https://github.com/aleksanderwozniak/table_calendar/assets/101862657/11699dc7-98e8-4248-aaba-78117b4770c4">
<br/>
<img width="440" alt="image" src="https://github.com/aleksanderwozniak/table_calendar/assets/101862657/d40d2dc8-929a-4f92-8a89-a01f962686ce">
