### PR TITLE
Feature / Add element states to semantics on cells

### DIFF
--- a/lib/src/widgets/cell_content.dart
+++ b/lib/src/widgets/cell_content.dart
@@ -48,13 +48,18 @@ class CellContent extends StatelessWidget {
     final dowLabel = DateFormat.EEEE(locale).format(day);
     final dayLabel = DateFormat.yMMMMd(locale).format(day);
     final semanticsLabel = '$dowLabel, $dayLabel';
+    // Required to announce to a11y services that the day is disabled
+    final semanticsIsEnabled = !isDisabled;
+    // Required to announce to a11y services that the day is a selected day or is under the range mode
+    final semanticsIsChecked = isSelected || isRangeStart || isWithinRange || isRangeEnd ? true : null;
 
-    Widget? cell =
-        calendarBuilders.prioritizedBuilder?.call(context, day, focusedDay);
+    Widget? cell = calendarBuilders.prioritizedBuilder?.call(context, day, focusedDay);
 
     if (cell != null) {
       return Semantics(
         label: semanticsLabel,
+        enabled: semanticsIsEnabled,
+        checked: semanticsIsChecked, // Use checked because selected does not works in web with some screen readers
         excludeSemantics: true,
         child: cell,
       );
@@ -87,16 +92,15 @@ class CellContent extends StatelessWidget {
             child: Text(text, style: calendarStyle.selectedTextStyle),
           );
     } else if (isRangeStart) {
-      cell =
-          calendarBuilders.rangeStartBuilder?.call(context, day, focusedDay) ??
-              AnimatedContainer(
-                duration: duration,
-                margin: margin,
-                padding: padding,
-                decoration: calendarStyle.rangeStartDecoration,
-                alignment: alignment,
-                child: Text(text, style: calendarStyle.rangeStartTextStyle),
-              );
+      cell = calendarBuilders.rangeStartBuilder?.call(context, day, focusedDay) ??
+          AnimatedContainer(
+            duration: duration,
+            margin: margin,
+            padding: padding,
+            decoration: calendarStyle.rangeStartDecoration,
+            alignment: alignment,
+            child: Text(text, style: calendarStyle.rangeStartTextStyle),
+          );
     } else if (isRangeEnd) {
       cell = calendarBuilders.rangeEndBuilder?.call(context, day, focusedDay) ??
           AnimatedContainer(
@@ -128,16 +132,15 @@ class CellContent extends StatelessWidget {
             child: Text(text, style: calendarStyle.holidayTextStyle),
           );
     } else if (isWithinRange) {
-      cell =
-          calendarBuilders.withinRangeBuilder?.call(context, day, focusedDay) ??
-              AnimatedContainer(
-                duration: duration,
-                margin: margin,
-                padding: padding,
-                decoration: calendarStyle.withinRangeDecoration,
-                alignment: alignment,
-                child: Text(text, style: calendarStyle.withinRangeTextStyle),
-              );
+      cell = calendarBuilders.withinRangeBuilder?.call(context, day, focusedDay) ??
+          AnimatedContainer(
+            duration: duration,
+            margin: margin,
+            padding: padding,
+            decoration: calendarStyle.withinRangeDecoration,
+            alignment: alignment,
+            child: Text(text, style: calendarStyle.withinRangeTextStyle),
+          );
     } else if (isOutside) {
       cell = calendarBuilders.outsideBuilder?.call(context, day, focusedDay) ??
           AnimatedContainer(
@@ -154,21 +157,19 @@ class CellContent extends StatelessWidget {
             duration: duration,
             margin: margin,
             padding: padding,
-            decoration: isWeekend
-                ? calendarStyle.weekendDecoration
-                : calendarStyle.defaultDecoration,
+            decoration: isWeekend ? calendarStyle.weekendDecoration : calendarStyle.defaultDecoration,
             alignment: alignment,
             child: Text(
               text,
-              style: isWeekend
-                  ? calendarStyle.weekendTextStyle
-                  : calendarStyle.defaultTextStyle,
+              style: isWeekend ? calendarStyle.weekendTextStyle : calendarStyle.defaultTextStyle,
             ),
           );
     }
 
     return Semantics(
       label: semanticsLabel,
+      enabled: semanticsIsEnabled,
+      checked: semanticsIsChecked, // Same as above
       excludeSemantics: true,
       child: cell,
     );


### PR DESCRIPTION
## Description
- Add enabled and checked properties to semantics on cells to improve accessibility

## How Has This Been Tested?
1. Run the example app
2. Enable any screen reader available in your device (Talkback for Android, VoiceOver for iOS, Narrator or NVDA for Windows)
3. Go to range, multi or complex example page
4. Select/unselect a day or a range of days
5. The screen reader should announce the selected days as a checked checkbox
6. For unselected days nothing change

## Type of Change
- Feature

# Notes
Semantics uses checked instead selected because selected is not announced correctly on web with some screen readers, to prevent to overflow the semantic UI with a lot of unchecked semantic checkboxes the checked property is only setted when the day is selected or is under a range.
This changes don't handle the logic to make the range selection accessible because there are so many ways to manage this so That is the responsibility of each developer