### PR TITLE
Managing better the disabled Style

### DIFF
--- a/lib/src/widgets/cell_content.dart
+++ b/lib/src/widgets/cell_content.dart
@@ -66,27 +66,7 @@ class CellContent extends StatelessWidget {
     final alignment = calendarStyle.cellAlignment;
     final duration = const Duration(milliseconds: 250);
 
-    if (isDisabled) {
-      cell = calendarBuilders.disabledBuilder?.call(context, day, focusedDay) ??
-          AnimatedContainer(
-            duration: duration,
-            margin: margin,
-            padding: padding,
-            decoration: calendarStyle.disabledDecoration,
-            alignment: alignment,
-            child: Text(text, style: calendarStyle.disabledTextStyle),
-          );
-    } else if (isSelected) {
-      cell = calendarBuilders.selectedBuilder?.call(context, day, focusedDay) ??
-          AnimatedContainer(
-            duration: duration,
-            margin: margin,
-            padding: padding,
-            decoration: calendarStyle.selectedDecoration,
-            alignment: alignment,
-            child: Text(text, style: calendarStyle.selectedTextStyle),
-          );
-    } else if (isRangeStart) {
+    if (isRangeStart) {
       cell =
           calendarBuilders.rangeStartBuilder?.call(context, day, focusedDay) ??
               AnimatedContainer(
@@ -147,6 +127,26 @@ class CellContent extends StatelessWidget {
             decoration: calendarStyle.outsideDecoration,
             alignment: alignment,
             child: Text(text, style: calendarStyle.outsideTextStyle),
+          );
+    } else if (isSelected) {
+      cell = calendarBuilders.selectedBuilder?.call(context, day, focusedDay) ??
+          AnimatedContainer(
+            duration: duration,
+            margin: margin,
+            padding: padding,
+            decoration: calendarStyle.selectedDecoration,
+            alignment: alignment,
+            child: Text(text, style: calendarStyle.selectedTextStyle),
+          );
+    } else if (isDisabled) {
+      cell = calendarBuilders.disabledBuilder?.call(context, day, focusedDay) ??
+          AnimatedContainer(
+            duration: duration,
+            margin: margin,
+            padding: padding,
+            decoration: calendarStyle.disabledDecoration,
+            alignment: alignment,
+            child: Text(text, style: calendarStyle.disabledTextStyle),
           );
     } else {
       cell = calendarBuilders.defaultBuilder?.call(context, day, focusedDay) ??


### PR DESCRIPTION
Improving the management of disabled tile style. By now, the disabled style was over everything, meaning that if you needed for example to have a todayStyle on a diabled tile, you couldn't. 
With this PR, the other styles will pass before the disabled style, which means that today, holiday , ... will pass before the disabled style.