### PR TITLE
Disable format change animation

### DIFF
--- a/lib/src/table_calendar_base.dart
+++ b/lib/src/table_calendar_base.dart
@@ -195,14 +195,9 @@ class _TableCalendarBaseState extends State<TableCalendarBase> {
               final height =
                   constraints.hasBoundedHeight ? constraints.maxHeight : value;
 
-              return AnimatedSize(
-                duration: widget.formatAnimationDuration,
-                curve: widget.formatAnimationCurve,
-                alignment: Alignment.topCenter,
-                child: SizedBox(
-                  height: height,
-                  child: child,
-                ),
+              return SizedBox(
+                height: height,
+                child: child,
               );
             },
             child: CalendarCore(


### PR DESCRIPTION
The original calendar does not allow to disable the format change animation.
When switching between CalendarFormat.week and CalendarFormat.month in the bottom off a SliverAppBar there were overflows because the animation of the format change was happening to slow. When trying to set the animation duration to 0ms,  the framework would warn with `flutter: A RenderAnimatedSize was mutated in its own performLayout implementation.`

Fixing this by disabling the format animation entirely.