### PR TITLE
feat: parameter to add a space under the calendar

### DIFF
--- a/lib/src/customization/calendar_style.dart
+++ b/lib/src/customization/calendar_style.dart
@@ -46,6 +46,9 @@ class CalendarStyle {
   /// Margin of single event markers. Affects each marker dot.
   final EdgeInsets markerMargin;
 
+  /// Space to add at the bottom of the Calendar. Useful if you added a top margin to the Markers
+  final double? bottomSpace;
+
   /// Margin of each individual day cell.
   final EdgeInsets cellMargin;
 
@@ -227,6 +230,7 @@ class CalendarStyle {
     this.rowDecoration = const BoxDecoration(),
     this.tableBorder = const TableBorder(),
     this.tablePadding = const EdgeInsets.all(0),
+    this.bottomSpace,
   });
 }
 

--- a/lib/src/table_calendar.dart
+++ b/lib/src/table_calendar.dart
@@ -504,6 +504,7 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
             availableCalendarFormats: widget.availableCalendarFormats,
             simpleSwipeConfig: widget.simpleSwipeConfig,
             sixWeekMonthsEnforced: widget.sixWeekMonthsEnforced,
+            bottomSpace: widget.calendarStyle.bottomSpace,
             onVerticalSwipe: _swipeCalendarFormat,
             onPageChanged: (focusedDay) {
               _focusedDay.value = focusedDay;

--- a/lib/src/table_calendar_base.dart
+++ b/lib/src/table_calendar_base.dart
@@ -24,6 +24,7 @@ class TableCalendarBase extends StatefulWidget {
   final Decoration? rowDecoration;
   final TableBorder? tableBorder;
   final EdgeInsets? tablePadding;
+  final double? bottomSpace;
   final Duration formatAnimationDuration;
   final Curve formatAnimationCurve;
   final bool pageAnimationEnabled;
@@ -55,6 +56,7 @@ class TableCalendarBase extends StatefulWidget {
     this.rowDecoration,
     this.tableBorder,
     this.tablePadding,
+    this.bottomSpace,
     this.formatAnimationDuration = const Duration(milliseconds: 200),
     this.formatAnimationCurve = Curves.linear,
     this.pageAnimationEnabled = true,
@@ -194,13 +196,14 @@ class _TableCalendarBaseState extends State<TableCalendarBase> {
             builder: (context, value, child) {
               final height =
                   constraints.hasBoundedHeight ? constraints.maxHeight : value;
+              final bottomMargin = widget.bottomSpace ?? 0.0;
 
               return AnimatedSize(
                 duration: widget.formatAnimationDuration,
                 curve: widget.formatAnimationCurve,
                 alignment: Alignment.topCenter,
                 child: SizedBox(
-                  height: height,
+                  height: height + bottomMargin,
                   child: child,
                 ),
               );


### PR DESCRIPTION
Currently, if you use the `markerMargin` parameter in order to add some top margin, the rendering of the Marker can be cropped at the bottom of the Calendar.
<img width="290" alt="Capture d’écran 2024-05-02 à 09 17 42" src="https://github.com/aleksanderwozniak/table_calendar/assets/33631420/e1cff665-349e-4fcb-ac45-f6993a336167">

The proposed solution would be to increase the `rowHeight` parameter in order to correctly handle the display of the markers. Sadly, this solution won't fix every needs.
I ended up with the solution of adding a new parameter that I called `bottomSpace` (could have been `bottomMargin`, but I thought that this name was misleading) which job is to add some more space in the `AnimatedContainer` rendering the Calendar, and thus allowing to correctly draw the Markers.
<img width="290" alt="Capture d’écran 2024-05-02 à 09 17 54" src="https://github.com/aleksanderwozniak/table_calendar/assets/33631420/581133b9-5aa2-4a7e-b957-9979777a7688">


There might be a sexier solution to this issue, but it'd ask a lot more work and brain juice, alongside with a lot more of refactoring. With this update, it won't break anything to the current users