### PR TITLE
fix: :bug: consider initial `rangeStartDay` value in range selection

### DIFF
--- a/lib/src/table_calendar.dart
+++ b/lib/src/table_calendar.dart
@@ -287,6 +287,12 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
     super.initState();
     _focusedDay = ValueNotifier(widget.focusedDay);
     _rangeSelectionMode = widget.rangeSelectionMode;
+
+    if (_isRangeSelectionOn && widget.onRangeSelected != null) {
+      if (widget.rangeStartDay != null && widget.rangeEndDay == null) {
+        _firstSelectedDay = widget.rangeStartDay;
+      }
+    }
   }
 
   @override


### PR DESCRIPTION
Hello there 👋🏻,

I just wanted to thank you for this great package! It's been really helpful for my Flutter projects 💪🏻💙

While using it in one of my apps, I found a small bug. It wasn't considering the starting day I set in `rangeStartDay` parameter in **Range Selection.** So, when I tapped on a day, it started selecting from the **Start Day** instead of just the **End Day** like it should 🐛

In this PR, I fixed the bug, tested it well, and now it works perfectly without affecting another functionality in the package 🛠️👍🏻

I hope you find it helpful 🙏🏻
Thanks again for your hard work in the Flutter community 💙 🙏🏻