### PR TITLE
Add dayTextFormatter property

### DIFF
--- a/lib/src/customization/calendar_style.dart
+++ b/lib/src/customization/calendar_style.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:flutter/widgets.dart';
+import 'package:table_calendar/table_calendar.dart';
 
 /// Class containing styling and configuration for `TableCalendar`'s content.
 class CalendarStyle {
@@ -151,6 +152,15 @@ class CalendarStyle {
   /// Padding for the internal `Table` widget.
   final EdgeInsets tablePadding;
 
+  /// Use to customize the text within each day cell.
+  /// Defaults to `'${date.day}'`, to show just the day number.
+  ///
+  /// Example usage:
+  /// ```dart
+  /// dayTextFormatter: (date, locale) => DateFormat.d(locale).format(date),
+  /// ```
+  final TextFormatter? dayTextFormatter;
+
   /// Creates a `CalendarStyle` used by `TableCalendar` widget.
   const CalendarStyle({
     this.isTodayHighlighted = true,
@@ -227,6 +237,7 @@ class CalendarStyle {
     this.rowDecoration = const BoxDecoration(),
     this.tableBorder = const TableBorder(),
     this.tablePadding = const EdgeInsets.all(0),
+    this.dayTextFormatter,
   });
 }
 

--- a/lib/src/widgets/cell_content.dart
+++ b/lib/src/widgets/cell_content.dart
@@ -60,7 +60,8 @@ class CellContent extends StatelessWidget {
       );
     }
 
-    final text = DateFormat.d(locale).format(day);
+    final text =
+        calendarStyle.dayTextFormatter?.call(day, locale) ?? '${day.day}';
     final margin = calendarStyle.cellMargin;
     final padding = calendarStyle.cellPadding;
     final alignment = calendarStyle.cellAlignment;

--- a/test/cell_content_test.dart
+++ b/test/cell_content_test.dart
@@ -11,6 +11,7 @@ import 'package:table_calendar/table_calendar.dart';
 Widget setupTestWidget(
   DateTime cellDay, {
   CalendarBuilders calendarBuilders = const CalendarBuilders(),
+  CalendarStyle calendarStyle = const CalendarStyle(),
   bool isDisabled = false,
   bool isToday = false,
   bool isWeekend = false,
@@ -23,8 +24,6 @@ Widget setupTestWidget(
   bool isTodayHighlighted = true,
   String? locale,
 }) {
-  final calendarStyle = CalendarStyle();
-
   return Directionality(
     textDirection: TextDirection.ltr,
     child: CellContent(
@@ -316,7 +315,7 @@ void main() {
   });
 
   group('CalendarBuilders Locale test:', () {
-    testWidgets('en locale', (tester) async {
+    testWidgets('en locale with default dayTextFormatter', (tester) async {
       final locale = 'en';
       initializeDateFormatting(locale, null);
 
@@ -328,11 +327,31 @@ void main() {
         ),
       );
 
+      final dayFinder = find.text('${cellDay.day}');
+      expect(dayFinder, findsOneWidget);
+    });
+
+    testWidgets('en locale with custom dayTextFormatter', (tester) async {
+      final locale = 'en';
+      initializeDateFormatting(locale, null);
+
+      final cellDay = DateTime.utc(2021, 7, 15);
+      await tester.pumpWidget(
+        setupTestWidget(
+          cellDay,
+          locale: locale,
+          calendarStyle: CalendarStyle(
+            dayTextFormatter: (date, locale) =>
+                DateFormat.d(locale).format(date),
+          ),
+        ),
+      );
+
       final dayFinder = find.text(DateFormat.d(locale).format(cellDay));
       expect(dayFinder, findsOneWidget);
     });
 
-    testWidgets('ar locale', (tester) async {
+    testWidgets('ar locale with default dayTextFormatter', (tester) async {
       final locale = 'ar';
       initializeDateFormatting(locale, null);
 
@@ -341,6 +360,26 @@ void main() {
         setupTestWidget(
           cellDay,
           locale: locale,
+        ),
+      );
+
+      final dayFinder = find.text('${cellDay.day}');
+      expect(dayFinder, findsOneWidget);
+    });
+
+    testWidgets('ar locale with custom dayTextFormatter', (tester) async {
+      final locale = 'ar';
+      initializeDateFormatting(locale, null);
+
+      final cellDay = DateTime.utc(2021, 7, 15);
+      await tester.pumpWidget(
+        setupTestWidget(
+          cellDay,
+          locale: locale,
+          calendarStyle: CalendarStyle(
+            dayTextFormatter: (date, locale) =>
+                DateFormat.d(locale).format(date),
+          ),
         ),
       );
 


### PR DESCRIPTION
Adds `dayTextFormatter` property that allows custom formatting of the text within each day cell.

Reverts the default behavior to showing just the day number, without any extra localized characters.

Fixes #863, #868 
Supersedes #879 

