### PR TITLE
This PR fixes ADA screen reader issues for days outside the current month in the calendar.

### DIFF
--- a/lib/src/table_calendar.dart
+++ b/lib/src/table_calendar.dart
@@ -344,10 +344,6 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
   }
 
   void _onDayTapped(DateTime day) {
-    final isOutside = day.month != _focusedDay.value.month;
-    if (isOutside && _shouldBlockOutsideDays) {
-      return;
-    }
 
     if (_isDayDisabled(day)) {
       return widget.onDisabledDayTapped?.call(day);
@@ -374,10 +370,6 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
   }
 
   void _onDayLongPressed(DateTime day) {
-    final isOutside = day.month != _focusedDay.value.month;
-    if (isOutside && _shouldBlockOutsideDays) {
-      return;
-    }
 
     if (_isDayDisabled(day)) {
       return widget.onDisabledDayLongPressed?.call(day);
@@ -556,6 +548,11 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
               return dowCell;
             },
             dayBuilder: (context, day, focusedMonth) {
+              final isOutside = day.month != focusedMonth.month;
+
+              if (isOutside && _shouldBlockOutsideDays) {
+                return Container();
+              }
               return GestureDetector(
                 behavior: widget.dayHitTestBehavior,
                 onTap: () => _onDayTapped(day),
@@ -571,10 +568,6 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
 
   Widget _buildCell(DateTime day, DateTime focusedDay) {
     final isOutside = day.month != focusedDay.month;
-
-    if (isOutside && _shouldBlockOutsideDays) {
-      return Container();
-    }
 
     return LayoutBuilder(
       builder: (context, constraints) {


### PR DESCRIPTION
Previously, the screen reader would announce "Text" on iOS for outside days when visibility is set to false, and on Android, users were able to tap the blank cells. This PR resolves these issues by returning a `Container` widget at the earliest possible stage. As a result, no `GestureDetector` is created, and the cells are not tappable. This ensures a better user experience and ADA compliance. Thank you.