### PR TITLE
[Feature] DaysOfweekStyle supports daysOfWeekStyleBuilder

### DIFF
--- a/lib/src/customization/days_of_week_style.dart
+++ b/lib/src/customization/days_of_week_style.dart
@@ -5,6 +5,9 @@ import 'package:flutter/widgets.dart';
 
 import '../shared/utils.dart' show TextFormatter;
 
+typedef DaysOfWeekStyleBuilder = TextStyle? Function(
+    BuildContext context, DateTime day);
+
 /// Class containing styling for `TableCalendar`'s days of week panel.
 class DaysOfWeekStyle {
   /// Use to customize days of week panel text (e.g. with different `DateFormat`).
@@ -26,11 +29,15 @@ class DaysOfWeekStyle {
   /// Style for weekend days on the top of calendar.
   final TextStyle weekendStyle;
 
+  /// Style builder for days of week on the top of calendar.
+  final DaysOfWeekStyleBuilder? daysOfWeekStyleBuilder;
+
   /// Creates a `DaysOfWeekStyle` used by `TableCalendar` widget.
   const DaysOfWeekStyle({
     this.dowTextFormatter,
     this.decoration = const BoxDecoration(),
     this.weekdayStyle = const TextStyle(color: const Color(0xFF4F4F4F)),
     this.weekendStyle = const TextStyle(color: const Color(0xFF6A6A6A)),
+    this.daysOfWeekStyleBuilder,
   });
 }

--- a/lib/src/table_calendar.dart
+++ b/lib/src/table_calendar.dart
@@ -541,13 +541,18 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
                 final isWeekend =
                     _isWeekend(day, weekendDays: widget.weekendDays);
 
+                final weekdayStyle = widget
+                    .daysOfWeekStyle.daysOfWeekStyleBuilder
+                    ?.call(context, day);
+
                 dowCell = Center(
                   child: ExcludeSemantics(
                     child: Text(
                       weekdayString,
-                      style: isWeekend
-                          ? widget.daysOfWeekStyle.weekendStyle
-                          : widget.daysOfWeekStyle.weekdayStyle,
+                      style: weekdayStyle ??
+                          (isWeekend
+                              ? widget.daysOfWeekStyle.weekendStyle
+                              : widget.daysOfWeekStyle.weekdayStyle),
                     ),
                   ),
                 );


### PR DESCRIPTION
Some calendar services mark Saturday in blue and Sunday in red.
So I suggest adding DaysOfWeekStyleBuilder to the DaysOfWeekStyle class

#### Usecase
```dart
daysOfWeekStyle: DaysOfWeekStyle(
  daysOfWeekStyleBuilder: (context, day) {
    if (day.weekday == DateTime.sunday) {
      return TextStyle(
        fontWeight: FontWeight.bold,
        color:  Colors.red,
      );
    } else if (day.weekday == DateTime.saturday) {
      return TextStyle(
        fontWeight: FontWeight.bold,
        color: Colors.blue,
      );
    } else {
      return TextStyle(
        fontWeight: FontWeight.bold,
        color: Colors.grey,
      );
    }
  },
)
```

#### Screenshot
<img width="329" alt="스크린샷 2024-12-11 오전 9 44 25" src="https://github.com/user-attachments/assets/c56a535f-c447-4e00-b8c3-0537a773c1af">
