### PR TITLE
feat: add parameter `onlyWeekdays`

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,50 +5,50 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -87,18 +87,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -111,10 +111,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -127,18 +127,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   simple_gesture_detector:
     dependency: transitive
     description:
@@ -151,39 +151,39 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   table_calendar:
     dependency: "direct main"
     description:
@@ -195,18 +195,18 @@ packages:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.4"
   typed_data:
     dependency: transitive
     description:
@@ -227,10 +227,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.1"
   web:
     dependency: transitive
     description:
@@ -240,5 +240,5 @@ packages:
     source: hosted
     version: "1.1.0"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/table_calendar.dart
+++ b/lib/src/table_calendar.dart
@@ -110,6 +110,9 @@ class TableCalendar<T> extends StatefulWidget {
   /// Whether to display week numbers on calendar.
   final bool weekNumbersVisible;
 
+  /// Wether to display only weekdays, will exclude all days in [weekendDays].
+  final bool onlyWeekdays;
+
   /// Used for setting the height of `TableCalendar`'s rows.
   final double rowHeight;
 
@@ -223,13 +226,9 @@ class TableCalendar<T> extends StatefulWidget {
     this.locale,
     this.rangeStartDay,
     this.rangeEndDay,
-    this.weekendDays = const [DateTime.saturday, DateTime.sunday],
+    this.weekendDays = kDefaultWeekendDays,
     this.calendarFormat = CalendarFormat.month,
-    this.availableCalendarFormats = const {
-      CalendarFormat.month: 'Month',
-      CalendarFormat.twoWeeks: '2 weeks',
-      CalendarFormat.week: 'Week',
-    },
+    this.availableCalendarFormats = kDefaultAvailableCalendarFormats,
     this.headerVisible = true,
     this.daysOfWeekVisible = true,
     this.pageJumpingEnabled = false,
@@ -237,6 +236,7 @@ class TableCalendar<T> extends StatefulWidget {
     this.sixWeekMonthsEnforced = false,
     this.shouldFillViewport = false,
     this.weekNumbersVisible = false,
+    this.onlyWeekdays = false,
     this.rowHeight = 52.0,
     this.daysOfWeekHeight = 16.0,
     this.formatAnimationDuration = const Duration(milliseconds: 200),
@@ -516,6 +516,8 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
             simpleSwipeConfig: widget.simpleSwipeConfig,
             sixWeekMonthsEnforced: widget.sixWeekMonthsEnforced,
             onVerticalSwipe: _swipeCalendarFormat,
+            onlyWeekdays: widget.onlyWeekdays,
+            weekendDays: widget.weekendDays,
             onPageChanged: (focusedDay) {
               _focusedDay.value = focusedDay;
               widget.onPageChanged?.call(focusedDay);
@@ -780,7 +782,7 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
 
   bool _isWeekend(
     DateTime day, {
-    List<int> weekendDays = const [DateTime.saturday, DateTime.sunday],
+    List<int> weekendDays = kDefaultWeekendDays,
   }) {
     return weekendDays.contains(day.weekday);
   }

--- a/lib/src/table_calendar_base.dart
+++ b/lib/src/table_calendar_base.dart
@@ -6,6 +6,13 @@ import 'package:simple_gesture_detector/simple_gesture_detector.dart';
 import 'package:table_calendar/src/shared/utils.dart';
 import 'package:table_calendar/src/widgets/calendar_core.dart';
 
+const kDefaultAvailableCalendarFormats = {
+  CalendarFormat.month: 'Month',
+  CalendarFormat.twoWeeks: '2 weeks',
+  CalendarFormat.week: 'Week',
+};
+const kDefaultWeekendDays = [DateTime.saturday, DateTime.sunday];
+
 class TableCalendarBase extends StatefulWidget {
   final DateTime firstDay;
   final DateTime lastDay;
@@ -35,6 +42,8 @@ class TableCalendarBase extends StatefulWidget {
   final SwipeCallback? onVerticalSwipe;
   final void Function(DateTime focusedDay)? onPageChanged;
   final void Function(PageController pageController)? onCalendarCreated;
+  final bool onlyWeekdays;
+  final List<int> weekendDays;
 
   TableCalendarBase({
     super.key,
@@ -65,14 +74,12 @@ class TableCalendarBase extends StatefulWidget {
       verticalThreshold: 25.0,
       swipeDetectionBehavior: SwipeDetectionBehavior.continuousDistinct,
     ),
-    this.availableCalendarFormats = const {
-      CalendarFormat.month: 'Month',
-      CalendarFormat.twoWeeks: '2 weeks',
-      CalendarFormat.week: 'Week',
-    },
+    this.availableCalendarFormats = kDefaultAvailableCalendarFormats,
     this.onVerticalSwipe,
     this.onPageChanged,
     this.onCalendarCreated,
+    this.onlyWeekdays = false,
+    this.weekendDays = kDefaultWeekendDays,
   })  : assert(!dowVisible || (dowHeight != null && dowBuilder != null)),
         assert(isSameDay(focusedDay, firstDay) || focusedDay.isAfter(firstDay)),
         assert(isSameDay(focusedDay, lastDay) || focusedDay.isBefore(lastDay));

--- a/lib/src/table_calendar_base.dart
+++ b/lib/src/table_calendar_base.dart
@@ -265,6 +265,8 @@ class _TableCalendarBaseState extends State<TableCalendarBase> {
               },
               dowBuilder: widget.dowBuilder,
               dayBuilder: widget.dayBuilder,
+              onlyWeekdays: widget.onlyWeekdays,
+              weekendDays: widget.weekendDays,
             ),
           ),
         );

--- a/lib/src/widgets/calendar_core.dart
+++ b/lib/src/widgets/calendar_core.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:table_calendar/src/shared/utils.dart';
+import 'package:table_calendar/src/table_calendar_base.dart';
 import 'package:table_calendar/src/widgets/calendar_page.dart';
 
 class CalendarCore extends StatelessWidget {
@@ -28,6 +29,8 @@ class CalendarCore extends StatelessWidget {
   final PageController? pageController;
   final ScrollPhysics? scrollPhysics;
   final void Function(int, DateTime) onPageChanged;
+  final bool onlyWeekdays;
+  final List<int> weekendDays;
 
   const CalendarCore({
     super.key,
@@ -53,6 +56,8 @@ class CalendarCore extends StatelessWidget {
     this.tableBorder,
     this.tablePadding,
     this.scrollPhysics,
+    this.onlyWeekdays = false,
+    this.weekendDays = kDefaultWeekendDays,
   }) : assert(!dowVisible || (dowHeight != null && dowBuilder != null));
 
   @override
@@ -64,7 +69,9 @@ class CalendarCore extends StatelessWidget {
       itemBuilder: (context, index) {
         final baseDay = _getBaseDay(calendarFormat, index);
         final visibleRange = _getVisibleRange(calendarFormat, baseDay);
-        final visibleDays = _daysInRange(visibleRange.start, visibleRange.end);
+        final visibleDays = !onlyWeekdays
+            ? _daysInRange(visibleRange.start, visibleRange.end)
+            : _weekDaysInRange(visibleRange.start, visibleRange.end);
 
         final actualDowHeight = dowVisible ? dowHeight! : 0.0;
         final constrainedRowHeight = constraints.hasBoundedHeight
@@ -79,6 +86,9 @@ class CalendarCore extends StatelessWidget {
           rowDecoration: rowDecoration,
           tableBorder: tableBorder,
           tablePadding: tablePadding,
+          daysInWeek: !onlyWeekdays
+              ? DateTime.daysPerWeek
+              : DateTime.daysPerWeek - weekendDays.length,
           dowBuilder: (context, day) {
             return SizedBox(
               height: dowHeight,
@@ -265,6 +275,15 @@ class CalendarCore extends StatelessWidget {
       dayCount,
       (index) => DateTime.utc(first.year, first.month, first.day + index),
     );
+  }
+
+  List<DateTime> _weekDaysInRange(DateTime first, DateTime last) {
+    final dayCount = last.difference(first).inDays + 1;
+    final weekdays = List.generate(
+      dayCount,
+      (index) => DateTime.utc(first.year, first.month, first.day + index),
+    )..removeWhere((e) => weekendDays.contains(e.weekday));
+    return weekdays;
   }
 
   DateTime _firstDayOfWeek(DateTime week) {

--- a/lib/src/widgets/calendar_page.dart
+++ b/lib/src/widgets/calendar_page.dart
@@ -15,12 +15,12 @@ class CalendarPage extends StatelessWidget {
   final bool dowVisible;
   final bool weekNumberVisible;
   final double? dowHeight;
+  final int daysInWeek;
 
   const CalendarPage({
-    super.key,
     required this.visibleDays,
-    this.dowBuilder,
     required this.dayBuilder,
+    this.dowBuilder,
     this.weekNumberBuilder,
     this.dowDecoration,
     this.rowDecoration,
@@ -29,6 +29,8 @@ class CalendarPage extends StatelessWidget {
     this.dowVisible = true,
     this.weekNumberVisible = false,
     this.dowHeight,
+    this.daysInWeek = DateTime.daysPerWeek,
+    super.key,
   })  : assert(!dowVisible || (dowHeight != null && dowBuilder != null)),
         assert(!weekNumberVisible || weekNumberBuilder != null);
 
@@ -55,7 +57,7 @@ class CalendarPage extends StatelessWidget {
   }
 
   Widget _buildWeekNumbers(BuildContext context) {
-    final rowAmount = visibleDays.length ~/ 7;
+    final rowAmount = visibleDays.length ~/ daysInWeek;
 
     return Column(
       children: [
@@ -63,7 +65,7 @@ class CalendarPage extends StatelessWidget {
         ...List.generate(
           rowAmount,
           (index) => Expanded(
-            child: weekNumberBuilder!(context, visibleDays[index * 7]),
+            child: weekNumberBuilder!(context, visibleDays[index * daysInWeek]),
           ),
         ),
       ],
@@ -74,22 +76,22 @@ class CalendarPage extends StatelessWidget {
     return TableRow(
       decoration: dowDecoration,
       children: List.generate(
-        7,
+        daysInWeek,
         (index) => dowBuilder!(context, visibleDays[index]),
       ),
     );
   }
 
   List<TableRow> _buildCalendarDays(BuildContext context) {
-    final rowAmount = visibleDays.length ~/ 7;
+    final rowAmount = visibleDays.length ~/ daysInWeek;
 
     return List.generate(
       rowAmount,
       (index) => TableRow(
         decoration: rowDecoration,
         children: List.generate(
-          7,
-          (id) => dayBuilder(context, visibleDays[index * 7 + id]),
+          daysInWeek,
+          (id) => dayBuilder(context, visibleDays[index * daysInWeek + id]),
         ),
       ),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,50 +5,50 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -59,46 +59,30 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  http:
-    dependency: transitive
-    description:
-      name: http
-      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.2"
-  http_parser:
-    dependency: transitive
-    description:
-      name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.2"
   intl:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "00f33b908655e606b86d2ade4710a231b802eec6f11e87e4ea3783fd72077a50"
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.1"
+    version: "0.19.0"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -119,10 +103,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -135,18 +119,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   simple_gesture_detector:
     dependency: "direct main"
     description:
@@ -159,63 +143,55 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.4.0"
+    version: "0.7.4"
   vector_math:
     dependency: transitive
     description:
@@ -228,18 +204,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.0"
+    version: "14.3.1"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -63,10 +63,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -95,10 +95,10 @@ packages:
     dependency: "direct dev"
     description:
       name: lint
-      sha256: d758a5211fce7fd3f5e316f804daefecdc34c7e53559716125e6da7388ae8565
+      sha256: "3cd03646de313481336500ba02eb34d07c590535525f154aae7fda7362aa07a9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.8.0"
   matcher:
     dependency: transitive
     description:
@@ -209,5 +209,5 @@ packages:
     source: hosted
     version: "14.3.1"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.7.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,6 @@
 name: table_calendar
 description: Highly customizable, feature-packed calendar widget for Flutter.
 version: 3.2.0
-author: Aleksander Woźniak <aleksanderwozniak96@gmail.com>
 homepage: https://github.com/aleksanderwozniak/table_calendar
 
 environment:
@@ -11,12 +10,10 @@ dependencies:
   flutter:
     sdk: flutter
 
-  intl: ^0.20.0
+  intl: ^0.19.0
   simple_gesture_detector: ^0.2.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   lint: ^2.0.1
-
-flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,10 +10,10 @@ dependencies:
   flutter:
     sdk: flutter
 
-  intl: ^0.19.0
-  simple_gesture_detector: ^0.2.0
+  intl: ^0.20.0
+  simple_gesture_detector: ^0.2.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  lint: ^2.0.1
+  lint: ^2.8.0

--- a/test/calendar_header_test.dart
+++ b/test/calendar_header_test.dart
@@ -6,11 +6,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart' as intl;
 import 'package:table_calendar/src/customization/header_style.dart';
 import 'package:table_calendar/src/shared/utils.dart';
+import 'package:table_calendar/src/table_calendar_base.dart';
 import 'package:table_calendar/src/widgets/calendar_header.dart';
 import 'package:table_calendar/src/widgets/custom_icon_button.dart';
 import 'package:table_calendar/src/widgets/format_button.dart';
-
-import 'common.dart';
 
 final focusedMonth = DateTime.utc(2021, 7, 15);
 
@@ -21,7 +20,8 @@ Widget setupTestWidget({
   VoidCallback? onHeaderTap,
   VoidCallback? onHeaderLongPress,
   Function(CalendarFormat)? onFormatButtonTap,
-  Map<CalendarFormat, String> availableCalendarFormats = calendarFormatMap,
+  Map<CalendarFormat, String> availableCalendarFormats =
+      kDefaultAvailableCalendarFormats,
 }) {
   return Directionality(
     textDirection: TextDirection.ltr,

--- a/test/common.dart
+++ b/test/common.dart
@@ -2,14 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:flutter/foundation.dart';
-import 'package:table_calendar/src/shared/utils.dart';
 
 ValueKey<String> dateToKey(DateTime date, {String prefix = ''}) {
   return ValueKey('$prefix${date.year}-${date.month}-${date.day}');
 }
-
-const calendarFormatMap = {
-  CalendarFormat.month: 'Month',
-  CalendarFormat.twoWeeks: 'Two weeks',
-  CalendarFormat.week: 'week',
-};

--- a/test/format_button_test.dart
+++ b/test/format_button_test.dart
@@ -6,8 +6,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:table_calendar/src/widgets/format_button.dart';
 import 'package:table_calendar/table_calendar.dart';
 
-import 'common.dart';
-
 Widget setupTestWidget(Widget child) {
   return Directionality(
     textDirection: TextDirection.ltr,
@@ -26,7 +24,7 @@ void main() {
         await tester.pumpWidget(
           setupTestWidget(
             FormatButton(
-              availableCalendarFormats: calendarFormatMap,
+              availableCalendarFormats: kDefaultAvailableCalendarFormats,
               calendarFormat: CalendarFormat.month,
               decoration: headerStyle.formatButtonDecoration,
               padding: headerStyle.formatButtonPadding,
@@ -57,7 +55,7 @@ void main() {
         await tester.pumpWidget(
           setupTestWidget(
             FormatButton(
-              availableCalendarFormats: calendarFormatMap,
+              availableCalendarFormats: kDefaultAvailableCalendarFormats,
               calendarFormat: CalendarFormat.twoWeeks,
               decoration: headerStyle.formatButtonDecoration,
               padding: headerStyle.formatButtonPadding,
@@ -88,7 +86,7 @@ void main() {
         await tester.pumpWidget(
           setupTestWidget(
             FormatButton(
-              availableCalendarFormats: calendarFormatMap,
+              availableCalendarFormats: kDefaultAvailableCalendarFormats,
               calendarFormat: CalendarFormat.week,
               decoration: headerStyle.formatButtonDecoration,
               padding: headerStyle.formatButtonPadding,
@@ -119,18 +117,18 @@ void main() {
 
         const currentFormatIndex = 0;
         final currentFormat =
-            calendarFormatMap.keys.elementAt(currentFormatIndex);
-        final currentFormatText =
-            calendarFormatMap.values.elementAt(currentFormatIndex);
+            kDefaultAvailableCalendarFormats.keys.elementAt(currentFormatIndex);
+        final currentFormatText = kDefaultAvailableCalendarFormats.values
+            .elementAt(currentFormatIndex);
 
         const nextFormatIndex = 1;
         final nextFormatText =
-            calendarFormatMap.values.elementAt(nextFormatIndex);
+            kDefaultAvailableCalendarFormats.values.elementAt(nextFormatIndex);
 
         await tester.pumpWidget(
           setupTestWidget(
             FormatButton(
-              availableCalendarFormats: calendarFormatMap,
+              availableCalendarFormats: kDefaultAvailableCalendarFormats,
               calendarFormat: currentFormat,
               decoration: headerStyle.formatButtonDecoration,
               padding: headerStyle.formatButtonPadding,
@@ -156,14 +154,14 @@ void main() {
 
         const currentFormatIndex = 0;
         final currentFormat =
-            calendarFormatMap.keys.elementAt(currentFormatIndex);
-        final currentFormatText =
-            calendarFormatMap.values.elementAt(currentFormatIndex);
+            kDefaultAvailableCalendarFormats.keys.elementAt(currentFormatIndex);
+        final currentFormatText = kDefaultAvailableCalendarFormats.values
+            .elementAt(currentFormatIndex);
 
         await tester.pumpWidget(
           setupTestWidget(
             FormatButton(
-              availableCalendarFormats: calendarFormatMap,
+              availableCalendarFormats: kDefaultAvailableCalendarFormats,
               calendarFormat: currentFormat,
               decoration: headerStyle.formatButtonDecoration,
               padding: headerStyle.formatButtonPadding,


### PR DESCRIPTION
## What does this change?

Rework of PR #786
fix #782 
fix #818

Added parameter `onlyWeekdays` to `TableCalendar` and made some small refactors to uniformize default values and rely on `DateTime.daysPerWeek` instead of hardcoded `7` values.

~~I've also downgraded the version constraint on the package `intl` to `^0.19.0` because it was causing some conflicts with other dependencies on my side (e.g: `melos`) while the package doesn't rely on any changes from version `0.20.0`.~~
Edit: Now with Flutter 3.32 we can fix `intl`'s version to `^0.20.0`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Ensure the tests (`flutter test`)
- [x] Ensure the analyzer and formatter pass (`flutter analyze`)