### PR TITLE
add already calculated markerSize to SingleMarkerBuilder

### DIFF
--- a/lib/src/customization/calendar_builders.dart
+++ b/lib/src/customization/calendar_builders.dart
@@ -11,6 +11,7 @@ typedef SingleMarkerBuilder<T> = Widget? Function(
   BuildContext context,
   DateTime day,
   T event,
+  double markerSize,
 );
 
 /// Signature for a function that creates an event marker for a given `day`.

--- a/lib/src/table_calendar.dart
+++ b/lib/src/table_calendar.dart
@@ -705,7 +705,7 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
 
   Widget _buildSingleMarker(DateTime day, T event, double markerSize) {
     return widget.calendarBuilders.singleMarkerBuilder
-            ?.call(context, day, event) ??
+            ?.call(context, day, event, markerSize) ??
         Container(
           width: markerSize,
           height: markerSize,


### PR DESCRIPTION
This PR simply add already calculated sizes of marker in SingleMarkerBuilder, in order to reuse them.

/!\ It's a breaking change.

rebase of #908 